### PR TITLE
Dev Environment Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea/
 venv/
 build/
+dist/
 clpipe.egg-info/
 Test_BIDS/
 # if you remove the above rule, at least ignore the following:
@@ -58,3 +59,7 @@ crashlytics-build.properties
 staticfiles
 .env
 TestFiles/dicom_info_13002.tsv
+
+#vscode
+.vscode
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ crashlytics-build.properties
 
 staticfiles
 .env
-TestFiles/dicom_info_13002.tsv
+TestFiles/
 
 #vscode
 .vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+wheel
+-e .


### PR DESCRIPTION
A few small adjustments to help with setting up dev environment.

Adding a `requirements.txt` lets a dev run `pip install -r requirements.txt` to get both the package's dependencies (`-e .` , 'editable' install of package, references `install_requires` list in setup.py) and libraries not necessary for package installation, but needed for dev environment (like pytest and wheel).

Ignore the whole `TestFiles` folder for reservation as a general sandbox space.

Additionally, ignore the `dist` build artifacts folder and some vscode IDE files.