### PR TITLE
Add resample wf

### DIFF
--- a/clpipe/data/defaultConfig.json
+++ b/clpipe/data/defaultConfig.json
@@ -94,6 +94,9 @@
 			"AROMARegression":{
 				"Algorithm": "fsl_regfilt"
 			},
+			"Resample":{
+				"Reference": "SET REFERENCE"
+			},
 			"ConfoundRegression": {
 				"Algorithm": "afni_3dTproject",
 				"Columns": ["csf", "csf_derivative1", "white_matter", "white_matter_derivative1"],

--- a/clpipe/data/defaultConfig.json
+++ b/clpipe/data/defaultConfig.json
@@ -95,7 +95,7 @@
 				"Algorithm": "fsl_regfilt"
 			},
 			"Resample":{
-				"Reference": "SET REFERENCE"
+				"ReferenceImage": "SET REFERENCE IMAGE"
 			},
 			"ConfoundRegression": {
 				"Algorithm": "afni_3dTproject",

--- a/clpipe/postprocutils/workflows.py
+++ b/clpipe/postprocutils/workflows.py
@@ -104,6 +104,13 @@ def build_postprocessing_workflow(postprocessing_config: dict, in_file: os.PathL
             current_wf = confound_regression_algorithm(mask_file=mask_file, base_dir=postproc_wf.base_dir, crashdump_dir=crashdump_dir)
 
             postproc_wf.connect(confounds_postproc_wf, "outputnode.out_file", current_wf, "inputnode.ort")
+        
+        elif step == "Resample":
+            reference_image = postprocessing_config["ProcessingStepOptions"][step]["ReferenceImage"]
+            if reference_image == "SET REFERENCE":
+                raise ValueError("No reference provided. Please set a path to reference in clpipe_config.json")
+
+            current_wf = build_resample_workflow(reference_image=reference_image, base_dir=postproc_wf.base_dir, crashdump_dir=crashdump_dir)
 
         # Send input of postproc workflow to first workflow
         if index == 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,3 +242,7 @@ def sample_melodic_mixing() -> Path:
 @pytest.fixture(scope="module")
 def sample_aroma_noise_ics() -> Path:
     return Path("tests/data/AROMAnoiseICs.csv").resolve()
+
+@pytest.fixture(scope="module")
+def sample_reference() -> Path:
+    return Path("tests/artifacts/tpl-MNIPediatricAsym_cohort-2_res-1_T1w.nii.gz").resolve()

--- a/tests/test_postprocess2.py
+++ b/tests/test_postprocess2.py
@@ -369,4 +369,25 @@ def test_postprocess2_wf_fslmaths_temporal_filter(artifact_dir, postprocessing_c
 
     assert True
 
+def test_postprocess2_wf_resample(artifact_dir, postprocessing_config, request, sample_raw_image, sample_reference, sample_raw_image_mask, plot_img, write_graph, helpers):
+
+    postprocessing_config["ProcessingSteps"] = ["SpatialSmoothing", "IntensityNormalization", "TemporalFiltering", "Resample"]
+    postprocessing_config["ProcessingStepOptions"]["Resample"]["Reference"] = str(sample_reference)
+
+    test_path = helpers.create_test_dir(artifact_dir, request.node.name)
+    out_path = test_path / "postProcessed.nii.gz"
+    
+    wf = build_postprocessing_workflow(postprocessing_config, in_file=sample_raw_image, out_file=out_path, tr=2, mask_file=sample_raw_image_mask,
+        base_dir=test_path, crashdump_dir=test_path)
+    
+    wf.run()
+
+    if write_graph:
+        wf.write_graph(dotfilename = test_path / "postProcessSubjectFlow", graph2use=write_graph)
+   
+    if plot_img:
+        helpers.plot_4D_img_slice(out_path, "postProcessed.png")
+
+    assert True
+
 

--- a/tests/test_postprocess2.py
+++ b/tests/test_postprocess2.py
@@ -372,7 +372,7 @@ def test_postprocess2_wf_fslmaths_temporal_filter(artifact_dir, postprocessing_c
 def test_postprocess2_wf_resample(artifact_dir, postprocessing_config, request, sample_raw_image, sample_reference, sample_raw_image_mask, plot_img, write_graph, helpers):
 
     postprocessing_config["ProcessingSteps"] = ["SpatialSmoothing", "IntensityNormalization", "TemporalFiltering", "Resample"]
-    postprocessing_config["ProcessingStepOptions"]["Resample"]["Reference"] = str(sample_reference)
+    postprocessing_config["ProcessingStepOptions"]["Resample"]["ReferenceImage"] = str(sample_reference)
 
     test_path = helpers.create_test_dir(artifact_dir, request.node.name)
     out_path = test_path / "postProcessed.nii.gz"

--- a/tests/test_postprocess2_wfs.py
+++ b/tests/test_postprocess2_wfs.py
@@ -161,7 +161,7 @@ def test_resample_wf(artifact_dir, sample_raw_image, sample_reference, plot_img,
 
     resampled_path = test_path / "resampled.nii.gz"
 
-    wf = build_resample_wf
+    wf = build_resample_workflow(
         reference_image=sample_reference, in_file=sample_raw_image, out_file=resampled_path, base_dir=test_path, crashdump_dir=test_path)
     wf.run()
 
@@ -169,4 +169,4 @@ def test_resample_wf(artifact_dir, sample_raw_image, sample_reference, plot_img,
         wf.write_graph(dotfilename = test_path / "resampleflow", graph2use=write_graph)
 
     if plot_img:
-        helpers.plot_4D_img_slice(regressed_path, "resample.png")
+        helpers.plot_4D_img_slice(resampled_path, "resample.png")

--- a/tests/test_postprocess2_wfs.py
+++ b/tests/test_postprocess2_wfs.py
@@ -153,3 +153,20 @@ def test_apply_aroma_fsl_regfilt_wf(artifact_dir, sample_raw_image, sample_melod
 
     if plot_img:
         helpers.plot_4D_img_slice(regressed_path, "aromaaplied.png")
+
+#TODO: Provide reference image
+def test_resample_wf(artifact_dir, sample_raw_image, sample_reference, plot_img, write_graph, request, helpers):
+    
+    test_path = helpers.create_test_dir(artifact_dir, request.node.name)
+
+    resampled_path = test_path / "resampled.nii.gz"
+
+    wf = build_resample_wf
+        reference_image=sample_reference, in_file=sample_raw_image, out_file=resampled_path, base_dir=test_path, crashdump_dir=test_path)
+    wf.run()
+
+    if write_graph:
+        wf.write_graph(dotfilename = test_path / "resampleflow", graph2use=write_graph)
+
+    if plot_img:
+        helpers.plot_4D_img_slice(regressed_path, "resample.png")


### PR DESCRIPTION
closes #152

Adds a resampling step option to the postprocessing workflow. This step uses the resample FLIRT node from glm_setup.py.

Adds new configuration options in the postproc2 section of clpipe_config.json

Adds tests for both the resample workflow in isolation and within a full workflow context.

Original Test Image:
![sample_raw](https://user-images.githubusercontent.com/34407871/152209331-5ffe398b-8706-48ad-9574-9890c03ed848.png)


Resampled Test Image:
![resample](https://user-images.githubusercontent.com/34407871/152209347-c2ac80ca-1df9-4093-abc7-94e07ee421b9.png)


Step in a full workflow context:
![postProcessSubjectFlowresample](https://user-images.githubusercontent.com/34407871/152208490-4868cf92-9a42-4f3f-917a-0c4e64a8035c.png)

