### PR TITLE
Process by image

### DIFF
--- a/clpipe/fmri_postprocess2.py
+++ b/clpipe/fmri_postprocess2.py
@@ -430,7 +430,7 @@ class PostProcessImage():
             raise NoiseFileNotFoundError(f"AROMA noise ICs file for sub-{self.subject_id} task-{self.task} not found.")
 
     def setup_logger(self):
-        self.logger = logging.getLogger(f"{self.__class__.__name__}.{self.image_file_name}")
+        self.logger = logging.getLogger(f"{self.__str__()}")
         self.logger.setLevel(logging.INFO)
         
         # Create log handler
@@ -471,11 +471,15 @@ class PostProcessImage():
         
         self.logger.debug(f"Postprocessed confound out file: {self.confound_out_file}")
     
-        self.confounds_wf = build_confound_postprocessing_workflow(self.postprocessing_config, confound_file = self.confounds,
-            out_file=self.confound_out_file, tr=self.tr,
-            name=f"{self.name}_Confound_Postprocessing_Pipeline",
-            mixing_file=self.mixing_file, noise_file=self.noise_file,
-            base_dir=self.working_dir, crashdump_dir=self.log_dir)
+        try:
+            self.confounds_wf = build_confound_postprocessing_workflow(self.postprocessing_config, confound_file = self.confounds,
+                out_file=self.confound_out_file, tr=self.tr,
+                name=f"{self.name}_Confound_Postprocessing_Pipeline",
+                mixing_file=self.mixing_file, noise_file=self.noise_file,
+                base_dir=self.working_dir, crashdump_dir=self.log_dir)
+        except ValueError as ve:
+            self.logger.warn(ve)
+            self.logger.warn("Skipping confounds processing")
 
     def setup_workflow(self):
         # Calculate the output file name

--- a/clpipe/fmri_postprocess2.py
+++ b/clpipe/fmri_postprocess2.py
@@ -354,6 +354,9 @@ class PostProcessImage():
         self.wf = None
         self.confounds_wf = None
 
+        self.name = f"Subject_{self.subject_id}_Task_{self.task}"
+        if self.run_num: self.name += f"_Run_{self.run_num}"
+
         self.setup_logger()
 
     def __str__(self):
@@ -457,7 +460,7 @@ class PostProcessImage():
     
         self.confounds_wf = build_confound_postprocessing_workflow(self.postprocessing_config, confound_file = self.confounds,
             out_file=self.confound_out_file, tr=self.tr,
-            name=f"Sub_{self.subject_id}_Confound_Postprocessing_Pipeline",
+            name=f"{self.name}_Confound_Postprocessing_Pipeline",
             mixing_file=self.mixing_file, noise_file=self.noise_file,
             base_dir=self.working_dir, crashdump_dir=self.log_dir)
 
@@ -469,7 +472,7 @@ class PostProcessImage():
 
         self.logger.info(f"Building postprocessing workflow for image: {self.image_file_name}")
         self.wf = build_postprocessing_workflow(self.postprocessing_config, in_file=self.image_path, out_file=out_file,
-            name=f"Sub_{self.subject_id}_Task_{self.task}_Postprocessing_Pipeline",
+            name=f"{self.name}_Postprocessing_Pipeline",
             mask_file=self.mask_image, confound_file = self.confounds,
             mixing_file=self.mixing_file, noise_file=self.noise_file,
             tr=self.tr, 

--- a/clpipe/postprocutils/workflows.py
+++ b/clpipe/postprocutils/workflows.py
@@ -19,7 +19,6 @@ CONFOUND_STEPS = {"TemporalFiltering", "AROMARegression"}
 
 class AlgorithmNotFoundError(ValueError):
     pass
-
     
 def build_postprocessing_workflow(postprocessing_config: dict, in_file: os.PathLike=None, out_file:os.PathLike=None,
     name:str = "Postprocessing_Pipeline", processing_steps: list=None, mask_file: os.PathLike=None, mixing_file: os.PathLike=None, 
@@ -148,6 +147,9 @@ def build_confound_postprocessing_workflow(postprocessing_config: dict, confound
 
     # Select steps that apply to confounds
     processing_steps = set(processing_steps) & CONFOUND_STEPS
+    
+    if len(list(processing_steps)) < 1:
+        raise ValueError("The confounds PostProcess workflow requires at least 1 processing step.") 
 
     input_node = pe.Node(IdentityInterface(fields=['in_file', 'out_file', 'columns', 'mixing_file', 'noise_file', 'mask_file'], mandatory_inputs=False), name="inputnode")
     output_node = pe.Node(IdentityInterface(fields=['out_file'], mandatory_inputs=True), name="outputnode")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def clpipe_fmriprep_dir(clpipe_bids_dir, sample_raw_image, sample_raw_image_mask
     sample_confounds_timeseries, sample_melodic_mixing, sample_aroma_noise_ics, sample_fmriprep_dataset_description):
     """Fixture which adds fmriprep subject folders and mock fmriprep output data to data_fmriprep directory."""
 
-    tasks = ["rest", "task1", "task2"]
+    tasks = ["rest", "task1", "task2_run-1", "task2_run-2"]
 
     image_space = "space-MNI152NLin2009cAsym"
     bold_suffix = "desc-preproc_bold.nii.gz"
@@ -145,8 +145,9 @@ def clpipe_fmriprep_dir(clpipe_bids_dir, sample_raw_image, sample_raw_image_mask
         subject_folder = fmriprep_dir / f"sub-{sub_num}" / "func"
         subject_folder.mkdir(parents=True)
         
+
         for task in tasks:
-            task_info = f"task-{task}_run-1"
+            task_info = f"task-{task}"
             
             shutil.copy(sample_raw_image, subject_folder / f"sub-{sub_num}_{task_info}_{image_space}_{bold_suffix}")
             shutil.copy(sample_raw_image_mask, subject_folder / f"sub-{sub_num}_{task_info}_{image_space}_{mask_suffix}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,3 +268,35 @@ def sample_fmriprep_dataset_description() -> Path:
 @pytest.fixture(scope="module")
 def sample_reference() -> Path:
     return Path("tests/artifacts/tpl-MNIPediatricAsym_cohort-2_res-1_T1w.nii.gz").resolve()
+
+@pytest.fixture(scope="module")
+def config_file(clpipe_dir):
+    return clpipe_dir / "clpipe_config.json"
+
+@pytest.fixture(scope="module")
+def config_file_confounds(clpipe_config_default, config_file):
+    clpipe_config_default["PostProcessingOptions2"]["ConfoundOptions"]["Include"] = True
+
+    with open(config_file, 'w') as f:
+        json.dump(clpipe_config_default, f)
+
+    return config_file
+
+@pytest.fixture(scope="module")
+def config_file_aroma(clpipe_config_default, config_file):
+    clpipe_config_default["PostProcessingOptions2"]["ProcessingSteps"] = ["AROMARegression", "SpatialSmoothing", "IntensityNormalization"]
+
+    with open(config_file, 'w') as f:
+        json.dump(clpipe_config_default, f)
+
+    return config_file
+
+@pytest.fixture(scope="module")
+def config_file_aroma_confounds(clpipe_config_default, config_file):
+    clpipe_config_default["PostProcessingOptions2"]["ConfoundOptions"]["Include"] = True
+    clpipe_config_default["PostProcessingOptions2"]["ProcessingSteps"] = ["AROMARegression", "SpatialSmoothing", "IntensityNormalization"]
+
+    with open(config_file, 'w') as f:
+        json.dump(clpipe_config_default, f)
+
+    return config_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,7 +294,7 @@ def config_file_aroma(clpipe_config_default, config_file):
 @pytest.fixture(scope="module")
 def config_file_aroma_confounds(clpipe_config_default, config_file):
     clpipe_config_default["PostProcessingOptions2"]["ConfoundOptions"]["Include"] = True
-    clpipe_config_default["PostProcessingOptions2"]["ProcessingSteps"] = ["AROMARegression", "SpatialSmoothing", "IntensityNormalization"]
+    clpipe_config_default["PostProcessingOptions2"]["ProcessingSteps"] = ["AROMARegression", "TemporalFiltering"]
 
     with open(config_file, 'w') as f:
         json.dump(clpipe_config_default, f)

--- a/tests/test_postprocess2.py
+++ b/tests/test_postprocess2.py
@@ -337,38 +337,39 @@ def test_postprocess_subject_with_confounds(clpipe_fmriprep_dir, config_file_con
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
     bids_dir = clpipe_fmriprep_dir / "data_BIDS"
     test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
+    pybids_db_path = test_dir / "bids_index"
     postproc_dir = Path(test_dir / "data_postprocessed")
     postproc_dir.mkdir(exist_ok=True)
     log_dir = Path(test_dir / "logs" / "postproc_logs")
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_confounds, pybids_db_path="bids_index", log_dir=log_dir)
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_confounds, pybids_db_path=pybids_db_path, log_dir=log_dir)
     subject()
 
 def test_postprocess_subject_aroma(clpipe_fmriprep_dir, config_file_aroma, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
     bids_dir = clpipe_fmriprep_dir / "data_BIDS"
     test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
+    pybids_db_path = test_dir / "bids_index"
     postproc_dir = Path(test_dir / "data_postprocessed")
     postproc_dir.mkdir(exist_ok=True)
     log_dir = Path(test_dir / "logs" / "postproc_logs")
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_aroma, pybids_db_path="bids_index", log_dir=log_dir)
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_aroma, pybids_db_path=pybids_db_path, log_dir=log_dir)
     subject()
 
 def test_postprocess_subject_aroma_with_confound_processing(clpipe_fmriprep_dir, config_file_aroma_confounds, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
     bids_dir = clpipe_fmriprep_dir / "data_BIDS"
     test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
+    pybids_db_path = test_dir / "bids_index"
     postproc_dir = Path(test_dir / "data_postprocessed")
     postproc_dir.mkdir(exist_ok=True)
     log_dir = Path(test_dir / "logs" / "postproc_logs")
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    postprocessing_config["ProcessingSteps"] = ["AROMARegression", "SpatialSmoothing", "IntensityNormalization"]
-
-    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_aroma_confounds, pybids_db_path="bids_index", log_dir=log_dir)
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_aroma_confounds, pybids_db_path=pybids_db_path, log_dir=log_dir)
     subject()
 
 def test_postprocess2_wf_fslmaths_temporal_filter(artifact_dir, postprocessing_config, request, sample_raw_image, sample_raw_image_mask, 

--- a/tests/test_postprocess2.py
+++ b/tests/test_postprocess2.py
@@ -317,37 +317,49 @@ def test_postprocess_subject_job_setup(clpipe_fmriprep_dir, artifact_dir, helper
     subject.setup()
 
     # Should be a task/run for each of rest, task1, task2-run1, task2-run2
-    assert len(subject.tasks) == 4
+    assert len(subject.image_jobs) == 4
 
-def test_postprocess_subject_job(clpipe_fmriprep_dir, artifact_dir, helpers, request):
+def test_postprocess_subject_job(clpipe_fmriprep_dir, config_file, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
     bids_dir = clpipe_fmriprep_dir / "data_BIDS"
-    config = clpipe_fmriprep_dir / "clpipe_config.json"
     test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
     postproc_dir = Path(test_dir / "data_postprocessed")
     postproc_dir.mkdir(exist_ok=True)
     log_dir = Path(test_dir / "logs" / "postproc_logs")
     log_dir.mkdir(parents=True, exist_ok=True)
+    pybids_db_path = test_dir / "BIDS_index"
 
-    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config, log_dir=log_dir)
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file, pybids_db_path=pybids_db_path, log_dir=log_dir)
 
     subject()
 
-def test_postprocess_subject_with_confounds(clpipe_fmriprep_dir, postprocessing_config, artifact_dir, helpers, request):
+def test_postprocess_subject_with_confounds(clpipe_fmriprep_dir, config_file_confounds, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
+    bids_dir = clpipe_fmriprep_dir / "data_BIDS"
     test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
     postproc_dir = Path(test_dir / "data_postprocessed")
     postproc_dir.mkdir(exist_ok=True)
     log_dir = Path(test_dir / "logs" / "postproc_logs")
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    postprocessing_config["ConfoundOptions"]["Include"] = True
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_confounds, pybids_db_path="bids_index", log_dir=log_dir)
+    subject()
 
-    subject = PostProcessSubjectJob('1', clpipe_fmriprep_dir, postproc_dir, postprocessing_config, pybids_db_path="bids_index", log_dir=log_dir)
-    subject.run()
-
-def test_postprocess_subject_aroma(clpipe_fmriprep_dir, postprocessing_config, artifact_dir, helpers, request):
+def test_postprocess_subject_aroma(clpipe_fmriprep_dir, config_file_aroma, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
+    bids_dir = clpipe_fmriprep_dir / "data_BIDS"
+    test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
+    postproc_dir = Path(test_dir / "data_postprocessed")
+    postproc_dir.mkdir(exist_ok=True)
+    log_dir = Path(test_dir / "logs" / "postproc_logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_aroma, pybids_db_path="bids_index", log_dir=log_dir)
+    subject()
+
+def test_postprocess_subject_aroma_with_confound_processing(clpipe_fmriprep_dir, config_file_aroma_confounds, artifact_dir, helpers, request):
+    fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
+    bids_dir = clpipe_fmriprep_dir / "data_BIDS"
     test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
     postproc_dir = Path(test_dir / "data_postprocessed")
     postproc_dir.mkdir(exist_ok=True)
@@ -356,21 +368,8 @@ def test_postprocess_subject_aroma(clpipe_fmriprep_dir, postprocessing_config, a
 
     postprocessing_config["ProcessingSteps"] = ["AROMARegression", "SpatialSmoothing", "IntensityNormalization"]
 
-    subject = PostProcessSubjectJob('1', clpipe_fmriprep_dir, postproc_dir, postprocessing_config, log_dir=log_dir)
-    subject.run()
-
-def test_postprocess_subject_aroma_with_confound_processing(clpipe_fmriprep_dir, postprocessing_config, artifact_dir, helpers, request):
-    fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
-    test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
-    postproc_dir = Path(test_dir / "data_postprocessed")
-    postproc_dir.mkdir(exist_ok=True)
-    log_dir = Path(test_dir / "logs" / "postproc_logs")
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    postprocessing_config["ProcessingSteps"] = ["AROMARegression", "SpatialSmoothing", "IntensityNormalization"]
-
-    subject = PostProcessSubjectJob('1', clpipe_fmriprep_dir, postproc_dir, postprocessing_config, log_dir=log_dir)
-    subject.run()
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config_file_aroma_confounds, pybids_db_path="bids_index", log_dir=log_dir)
+    subject()
 
 def test_postprocess2_wf_fslmaths_temporal_filter(artifact_dir, postprocessing_config, request, sample_raw_image, sample_raw_image_mask, 
     sample_confounds_timeseries, plot_img, write_graph, helpers):

--- a/tests/test_postprocess2.py
+++ b/tests/test_postprocess2.py
@@ -298,7 +298,7 @@ def test_prepare_confounds_aroma(sample_confounds_timeseries, postprocessing_con
         base_dir=test_path, crashdump_dir=test_path, tr=2)
 
     cf_workflow.run()
-    
+    S
     assert True
 
 def test_postprocess_subject_job_setup(clpipe_fmriprep_dir, artifact_dir, helpers, request):
@@ -310,8 +310,9 @@ def test_postprocess_subject_job_setup(clpipe_fmriprep_dir, artifact_dir, helper
     postproc_dir.mkdir(exist_ok=True)
     log_dir = Path(test_dir / "logs" / "postproc_logs")
     log_dir.mkdir(parents=True, exist_ok=True)
+    pybids_db_path = test_dir / "BIDS_index"
 
-    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config, log_dir=log_dir)
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config, pybids_db_path=pybids_db_path, log_dir=log_dir)
 
     subject.setup()
 
@@ -342,7 +343,7 @@ def test_postprocess_subject_with_confounds(clpipe_fmriprep_dir, postprocessing_
 
     postprocessing_config["ConfoundOptions"]["Include"] = True
 
-    subject = PostProcessSubjectJob('1', clpipe_fmriprep_dir, postproc_dir, postprocessing_config, log_dir=log_dir)
+    subject = PostProcessSubjectJob('1', clpipe_fmriprep_dir, postproc_dir, postprocessing_config, pybids_db_path="bids_index", log_dir=log_dir)
     subject.run()
 
 def test_postprocess_subject_aroma(clpipe_fmriprep_dir, postprocessing_config, artifact_dir, helpers, request):

--- a/tests/test_postprocess2.py
+++ b/tests/test_postprocess2.py
@@ -270,6 +270,7 @@ def test_postprocess_subjects_job(clpipe_fmriprep_dir, artifact_dir, helpers, re
 
     jobs = PostProcessSubjectJobs(bids_dir, fmriprep_dir, postproc_dir, config,
         log_dir=log_dir, pybids_db_path=pybids_db_path)
+    jobs.run()
 
     assert len(jobs.post_process_jobs) == 8
 
@@ -300,6 +301,23 @@ def test_prepare_confounds_aroma(sample_confounds_timeseries, postprocessing_con
     
     assert True
 
+def test_postprocess_subject_job_setup(clpipe_fmriprep_dir, artifact_dir, helpers, request):
+    fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
+    bids_dir = clpipe_fmriprep_dir / "data_BIDS"
+    config = clpipe_fmriprep_dir / "clpipe_config.json"
+    test_dir = helpers.create_test_dir(artifact_dir, request.node.name)
+    postproc_dir = Path(test_dir / "data_postprocessed")
+    postproc_dir.mkdir(exist_ok=True)
+    log_dir = Path(test_dir / "logs" / "postproc_logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config, log_dir=log_dir)
+
+    subject.setup()
+
+    # Should be a task/run for each of rest, task1, task2-run1, task2-run2
+    assert len(subject.tasks) == 4
+
 def test_postprocess_subject_job(clpipe_fmriprep_dir, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"
     bids_dir = clpipe_fmriprep_dir / "data_BIDS"
@@ -311,7 +329,8 @@ def test_postprocess_subject_job(clpipe_fmriprep_dir, artifact_dir, helpers, req
     log_dir.mkdir(parents=True, exist_ok=True)
 
     subject = PostProcessSubjectJob('1', bids_dir, fmriprep_dir, postproc_dir, config, log_dir=log_dir)
-    subject.run()
+
+    subject()
 
 def test_postprocess_subject_with_confounds(clpipe_fmriprep_dir, postprocessing_config, artifact_dir, helpers, request):
     fmriprep_dir = clpipe_fmriprep_dir / "data_fmriprep" / "fmriprep"


### PR DESCRIPTION
Closes #159

Also addresses #165

Postproc2 now properly picks up on tasks with multiple runs:

![image](https://user-images.githubusercontent.com/34407871/154292663-8dbc88d4-1a69-4ae7-a563-7620fa63cd3f.png)

The basic unit of processing job is now "SubjectImage," the combination of subject, task, and run, instead of "SubjectTaskJob," which did not account for multiple runs.

The job of finding images is moved up to the subject processing job, while identification of the TR is moved down to the SubjectImage job.

Additionally, try/catch logic is added to handling missing confounds/AROMA files.
