### PR TITLE
Fsl regfilt r

### DIFF
--- a/clpipe/data/R_scripts/fsl_regfilt.R
+++ b/clpipe/data/R_scripts/fsl_regfilt.R
@@ -1,0 +1,89 @@
+# This script was written by Dr. Michael Hallquist and is copied from https://github.com/UNCDEPENdLab/fmri_processing_scripts/blob/master/fsl_regfilt.R
+
+#!/usr/bin/env Rscript
+args = commandArgs(trailingOnly=TRUE)
+
+if (length(args) < 3 || length(args) > 5) {
+  stop("Expects at least three arguments: input_file, melodic_mix, motion_ics_file, <njobs=4>, <output_fname>.", call.=FALSE)
+}
+
+#handle package dependencies
+for (pkg in c("speedglm", "oro.nifti", "doParallel", "tictoc", "pracma")) {
+  if (!suppressMessages(require(pkg, character.only=TRUE))) {
+    message("Installing missing package dependency: ", pkg)
+    install.packages(pkg, repo="https://archive.linux.duke.edu/cran/")
+    suppressMessages(require(pkg, character.only=TRUE))
+  }
+}
+
+#core worker function to implement 'non-aggressive' approach in which all component time series are predictors and we only pull out partial effectse of noise components
+partialLm <- function(y, X, ivs=NULL) {
+  m <- speedlm.fit(y=y, X=X, intercept=FALSE)
+  pred <- X[,ivs] %*% coef(m)[ivs]
+  return(as.vector(y - pred))
+}
+
+# set defaults
+njobs <- 4
+output_fname <- "ica_aroma/denoised_func_data_nonaggr"
+
+dataset <- args[[1]]
+melodic.mix.df <- args[[2]]
+motion_components <- args[[3]]
+
+if (length(args) > 3) njobs <- as.integer(args[[4]])
+if (length(args) > 4) output_fname <- args[[5]]
+
+output_fname <- sub("\\.nii(\\.gz)*$", "", output_fname, perl = TRUE) # strip extension to avoid double extension in writeNIfTI
+
+stopifnot(file.exists(dataset))
+stopifnot(file.exists(motion_components))  
+
+message("Running fslRegFilt.R with ", njobs, " jobs")
+message("Reading input dataset: ", dataset)
+fmri_ts_data <- readNIfTI(dataset, reorient=FALSE)
+
+melmix <- data.matrix(read.table(melodic.mix.df, header=FALSE, colClasses="numeric"))
+
+nonconst <- apply(fmri_ts_data, c(1,2,3), function(ts) { !all(ts==ts[1]) })
+mi <- which(nonconst==TRUE, arr.ind=TRUE)
+
+toprocess <- apply(fmri_ts_data, 4, function(x) x[nonconst]) # becomes a voxels x timepoints matrix
+rownames(toprocess) <- 1:nrow(toprocess) #used to set progress bar inside loop
+message("fMRI data to analyze consist of ", nrow(toprocess), " voxels and ", ncol(toprocess), " timepoints")
+
+#contains a comma-separated list of flagged components
+badics <- as.numeric(strsplit(scan(motion_components, what="character"), ",")[[1]])
+cat("The following components will be removed from the data using partial regression:\n")
+cat(paste(badics, collapse=", "), "\n\n")
+
+if (njobs > 1) {
+    cl <- parallel::makePSOCKcluster(njobs, outfile = "")
+    registerDoParallel(cl)
+} else {
+    registerDoSEQ()
+}
+
+message("Starting voxelwise partial regression fitting")
+tic("partialLm fitting")
+system.time(res <- foreach(v=iter(toprocess, by="row"), .noexport="fmri_ts_data", .packages="speedglm", .inorder=TRUE, .multicombine=TRUE, .combine=rbind) %dopar% { #, .options.snow = opts
+  it <- as.numeric(row.names(v)[1]) #use row number to set progress bar
+  if (it %% 1000 == 0) { cat("  Fitting voxel: ", it, "\n") }
+
+  partialLm(matrix(v, ncol=1), melmix, badics)
+})
+toc()
+
+if (njobs > 1) {
+  stopCluster(cl)
+}
+
+#back to old repmat strategy
+miassign <- cbind(pracma::repmat(mi, ncol(res), 1), rep(1:ncol(res), each=nrow(res)))
+
+fmri_ts_data@.Data[miassign] <- res
+
+#add min/max to header to have it play well across packages
+fmri_ts_data@cal_min <- min(fmri_ts_data)
+fmri_ts_data@cal_max <- max(fmri_ts_data)
+writeNIfTI(fmri_ts_data, filename = output_fname)

--- a/clpipe/fmri_postprocess2.py
+++ b/clpipe/fmri_postprocess2.py
@@ -473,6 +473,12 @@ class PostProcessImage():
                 name=f"{self.name}_Confound_Postprocessing_Pipeline",
                 mixing_file=self.mixing_file, noise_file=self.noise_file,
                 base_dir=self.working_dir, crashdump_dir=self.log_dir)
+
+            # Draw the confound workflow's process graph if requested in config
+            if self.postprocessing_config["WriteProcessGraph"]:
+                graph_image_path = self.out_dir / "confounds_processsing_plan.dot"
+                self.logger.info(f"Drawing confounds workflow graph: {graph_image_path}")
+                self.confounds_wf.write_graph(dotfilename = graph_image_path, graph2use="colored")
         except ValueError as ve:
             self.logger.warn(ve)
             self.logger.warn("Skipping confounds processing")
@@ -490,6 +496,12 @@ class PostProcessImage():
             mixing_file=self.mixing_file, noise_file=self.noise_file,
             tr=self.tr, 
             base_dir=self.working_dir, crashdump_dir=self.log_dir)
+        
+        # Draw the workflow's process graph if requested in config
+        if self.postprocessing_config["WriteProcessGraph"]:
+            graph_image_path = self.out_dir / "processing_plan.dot"
+            self.logger.info(f"Drawing workflow graph: {graph_image_path}")
+            self.wf.write_graph(dotfilename = graph_image_path, graph2use="colored")
 
     def setup(self):
         self.get_aroma_files()
@@ -499,24 +511,12 @@ class PostProcessImage():
         self.setup_confounds_workflow()
 
     def run(self):
-        # Draw the workflow's process graph if requested in config
-        if self.postprocessing_config["WriteProcessGraph"]:
-            graph_image_path = self.out_dir / "process_graph.dot"
-            self.logger.info(f"Drawing workflow graph: {graph_image_path}")
-            self.wf.write_graph(dotfilename = graph_image_path, graph2use="flat")
-
         self.logger.info(f"Running postprocessing workflow for image: {self.image_file_name}")
         self.wf.run()
         self.logger.info(f"Postprocessing workflow complete for image: {self.image_file_name}")
 
         # Process confounds, if this option was included
         if self.confounds_wf:
-            # Draw the workflow's process graph if requested in config
-            if self.postprocessing_config["WriteProcessGraph"]:
-                graph_image_path = self.out_dir / "confounds_process_graph.dot"
-                self.logger.info(f"Drawing confounds workflow graph: {graph_image_path}")
-                self.confounds_wf.write_graph(dotfilename = graph_image_path, graph2use="flat")
-
             self.logger.info("Postprocessing confounds")
             self.confounds_wf.run()
             

--- a/clpipe/fmri_postprocess2.py
+++ b/clpipe/fmri_postprocess2.py
@@ -499,27 +499,27 @@ class PostProcessImage():
         self.setup_confounds_workflow()
 
     def run(self):
-        self.logger.info(f"Running postprocessing workflow for image: {self.image_file_name}")
-        self.wf.run()
-        self.logger.info(f"Postprocessing workflow complete for image: {self.image_file_name}")
-
         # Draw the workflow's process graph if requested in config
         if self.postprocessing_config["WriteProcessGraph"]:
             graph_image_path = self.out_dir / "process_graph.dot"
             self.logger.info(f"Drawing workflow graph: {graph_image_path}")
-            self.wf.write_graph(dotfilename = graph_image_path, graph2use="colored")
+            self.wf.write_graph(dotfilename = graph_image_path, graph2use="flat")
+
+        self.logger.info(f"Running postprocessing workflow for image: {self.image_file_name}")
+        self.wf.run()
+        self.logger.info(f"Postprocessing workflow complete for image: {self.image_file_name}")
 
         # Process confounds, if this option was included
         if self.confounds_wf:
-            self.logger.info("Postprocessing confounds")
-            self.confounds_wf.run()
-            
             # Draw the workflow's process graph if requested in config
             if self.postprocessing_config["WriteProcessGraph"]:
                 graph_image_path = self.out_dir / "confounds_process_graph.dot"
                 self.logger.info(f"Drawing confounds workflow graph: {graph_image_path}")
-                self.confounds_wf.write_graph(dotfilename = graph_image_path, graph2use="colored")
+                self.confounds_wf.write_graph(dotfilename = graph_image_path, graph2use="flat")
 
+            self.logger.info("Postprocessing confounds")
+            self.confounds_wf.run()
+            
     def __call__(self):
         self.setup()
         self.run()

--- a/clpipe/postprocutils/r_setup.py
+++ b/clpipe/postprocutils/r_setup.py
@@ -1,0 +1,16 @@
+import os
+from pathlib import Path
+import getpass
+import pkg_resources
+
+CLPIPE_R_LIBS_PATH = Path("/nas/longleaf/home/") / Path(getpass.getuser()) / Path(".local/lib/clpipe_R")
+
+def setup_clpipe_R_lib():
+    """
+    Sets up an R library folder for R dependencies
+    """
+    os.environ['R_LIBS_USER'] = str(CLPIPE_R_LIBS_PATH)
+
+    print(CLPIPE_R_LIBS_PATH)
+    if not CLPIPE_R_LIBS_PATH.exists():
+        CLPIPE_R_LIBS_PATH.mkdir(parents=True)

--- a/clpipe/postprocutils/workflows.py
+++ b/clpipe/postprocutils/workflows.py
@@ -2,6 +2,7 @@ import os
 
 from math import sqrt, log
 
+#TODO: import these without specifying, to help with code readability
 from nipype.interfaces.fsl.maths import MeanImage, BinaryMaths, MedianImage, ApplyMask, TemporalFilter
 from nipype.interfaces.fsl.utils import ImageStats, FilterRegressor
 from nipype.interfaces.afni import TProject

--- a/clpipe/utils.py
+++ b/clpipe/utils.py
@@ -1,5 +1,8 @@
 import click
 import os
+
+from nipype.utils.filemanip import split_filename
+
 @click.command()
 @click.argument('subjects', nargs=-1, required=False, default=None)
 @click.option('-config_file', type=click.Path(exists=True, dir_okay=False, file_okay=True), default=None,
@@ -15,3 +18,20 @@ def command_log(config):
     ctx = click.get_current_context()
     print(ctx.info_name)
     print(os.getlogin())
+
+def append_suffix(original_path, suffix_to_add):
+    """
+    Appends on a new suffix to a file path, preserving the exstension.
+
+    Example:
+
+    original_path: sub-01_ses-nov2016_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz
+    suffix_to_add: extra
+
+    output: sub-01_ses-nov2016_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold_extra.nii.gz
+    """
+    base, image_name, exstension = split_filename(original_path)
+    out_stem = image_name + '_' + suffix_to_add + exstension
+    out_file = os.path.join(base, out_stem)
+
+    return out_file

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='clpipe',
                         'pybids>=0.14.0',
                         'templateflow',
                         'deepdiff'],
+      package_data={'clpipe': ['R_scripts/*.R']},
       entry_points='''
       [console_scripts]
       fmriprep_process=clpipe.fmri_preprocess:fmriprep_process


### PR DESCRIPTION
FSL's regfilt command won't work with the confounds-as-nifty pipeline, despite trying several attempts at changing the nii's format and digging into the regfilt code a bit.

This change adds in Dr. Hallquist's solution, which is an R script variant of fsl_regfilt.

Now, the confounds pipeline will always default to fsl_regfilt_R, a new workflow which calls a node that wraps this R script.

As a result of adding an R dependency, there are a few utility additions to support this.