### PR TITLE
Tutorial: Project Setup through BIDS Validation

### DIFF
--- a/docs/bids_validation_tutorial.md
+++ b/docs/bids_validation_tutorial.md
@@ -1,0 +1,165 @@
+# BIDS Validation
+
+
+## Running the bids_validate command
+
+Use the `bids_validate` command without the `-submit` flag to check your execution plan:
+
+```
+bids_validate -config_file clpipe_config.json
+```
+
+```
+sbatch --no-requeue -n 1 --mem=3000 --time=1:0:0 --cpus-per-task=1 --job-name="BIDSValidator" --output=<your system's path>/clpipe_tutorial_project/Output-BIDSValidator-jobid-%j.out --wrap="singularity run --cleanenv -B /proj,/pine,/nas02,/nas <your validation image path>/validator.simg <your system's path>/clpipe_tutorial_project/data_BIDS"
+```
+
+If you are happy with the submission plan, add the submit flag:
+
+```
+bids_validate -config_file clpipe_config.json -submit
+```
+
+## Interpreting & Fixing the Validation Results
+
+You should see the output of your validation at the root of your project directory, like this (it really should end up in the logs folder - we're working on it!):
+
+```
+├── analyses
+├── clpipe_config.json
+├── conversion_config.json
+├── data_BIDS
+├── data_DICOMs
+├── data_fmriprep
+├── data_GLMPrep
+├── data_onsets
+├── data_postproc
+├── data_ROI_ts
+├── glm_config.json
+├── l1_feat_folders
+├── l1_fsfs
+├── l2_fsfs
+├── l2_gfeat_folders
+├── l2_sublist.csv
+├── logs
+├── Output-BIDSValidator-jobid-41362508.out
+```
+
+Now open this file - there will be two types of issues, `[ERR]` for errors and `[WARN]` for warnings. The errors must be resolved for the dataset to be considered a valid BIDS dataset. Warnings are important to review for insight into further potential problems in the data, but do not invalidate your dataset.
+
+> Note: fMRIPrep runs BIDS validation again before it starts processing, and will not start if the dataset contains any errors!
+
+### Error #1
+
+Let's start with the first error:
+
+```
+	[31m1: [ERR] Files with such naming scheme are not part of BIDS specification...
+		./tmp_dcm2bids/log/sub-0003_2022-03-23T155433.420971.log
+			Evidence: sub-0003_2022-03-23T155433.420971.log
+		./tmp_dcm2bids/log/sub-0004_2022-03-23T153854.035740.log
+```
+
+If you look closely, the BIDS validator is complaining about the tmp_dcm2bids files, which are not intended to be part of the dataset! In order to ask for this folder to not be considered part of the BIDS dataset, we need to specify this in a `.bidsignore` file.
+
+Create a `.bidsignore` file in your BIDS directory:
+
+```
+touch data_BIDS/.bidsignore
+```
+
+Now, open this file and add the folder you'd like to ignore:
+
+```
+tmp_dcm2bids
+```
+
+Next, rerun the validation command and open your new validation results (make sure you aren't looking at the old results file again!). You should see that the error message about the tmp_dcm2bids folder is gone.
+
+> Note: We plan to have clpipe automatically create this file soon
+
+### Error #2
+
+The next error should look like this:
+
+```
+[31m1: [ERR] 'IntendedFor' field needs to point to an existing file. (code: 37 - INTENDED_FOR)[39m
+		./sub-0003/fmap/sub-0003_dir-AP_epi.nii.gz
+			Evidence: func/sub-0003_task-rest_bold.nii.gz
+```
+
+It looks like sub-0003's 'IntendedFor' filed points to a non existent file. Let's verify this by opening the subject's .json sidecar, located at `data_BIDS/sub-0003/fmap/sub-0003_dir-AP_epi.json`
+
+At the bottom of the file, we can see that sub-0003's IntendedFor field is pointing to a function image, but this subject has no functional images!
+
+```
+...
+    "InPlanePhaseEncodingDirectionDICOM": "COL",
+    "ConversionSoftware": "dcm2niix",
+    "ConversionSoftwareVersion": "v1.0.20190902",
+    "Dcm2bidsVersion": "2.1.6",
+    "IntendedFor": "func/sub-0003_task-rest_bold.nii.gz"
+}
+```
+
+Let's erase this field (don't forget to remove the comma on the line before it, too):
+```
+...
+    "InPlanePhaseEncodingDirectionDICOM": "COL",
+    "ConversionSoftware": "dcm2niix",
+    "ConversionSoftwareVersion": "v1.0.20190902",
+    "Dcm2bidsVersion": "2.1.6"
+}
+```
+
+And try again. Now, the error message for this subject should be gone.
+
+### Error #3
+
+The final error is asking for the 'TaskName' on our rest data:
+
+```
+[31m1: [ERR] You have to define 'TaskName' for this file. (code: 50 - TASK_NAME_MUST_DEFINE)[39m
+		./sub-0004/func/sub-0004_task-rest_bold.nii.gz
+		./sub-0005/func/sub-0005_task-rest_bold.nii.gz
+		./sub-0006/func/sub-0006_task-rest_bold.nii.gz
+		./sub-0007/func/sub-0007_task-rest_bold.nii.gz
+```
+
+This error is asking us to include a "TaskName" field in our .json sidecar files. Luckily, we can ask dcm2bids to specify this in the `conversion_config.json` file. Open up `conversion_config.json` and add the `sidecarChanges` field to specify a task name to automatically add to our generated sidecar files:
+
+```
+{
+    "descriptions": [
+        {
+        "dataType": "func",
+        "modalityLabel": "bold",
+        "customLabels": "task-rest",
+        "sidecarChanges":{
+            "TaskName": "rest"
+        },
+        "criteria": {
+            "SeriesDescription": "Axial_EPI-FMRI*"
+            }
+        },
+...
+```
+
+For this change, we will need to rerun the BIDS conversion. However, because these rest images were already successfully sorted into BIDS format, we will need to add the `-overwrite` flag to our `convert2bids` coomand (which calls dcm2bid's `--forceDcm2niix` and `--clobber` options under the hood)
+
+Now we will have a clean slate when rerunning convert2bids, and we can see that the rest image sidecars now contain the `TaskName` field:
+
+```
+...
+    "InPlanePhaseEncodingDirectionDICOM": "COL",
+    "ConversionSoftware": "dcm2niix",
+    "ConversionSoftwareVersion": "v1.0.20190902",
+    "Dcm2bidsVersion": "2.1.6",
+    "TaskName": "rest"
+}
+```
+
+Finally, because we used the `-overwrite` flag, sub-0003's IntendedFor field will be re-inserted (Error #2). Repeat the fix for this problem by removing the IntendedFor field from sub-0003's sidecar .json.
+
+Now, rerun bids_validate - you should be completely free of errors!
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
-    'sphinx-jsonschema'
+    'sphinx-jsonschema',
+    'myst_parser'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -51,8 +52,8 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
+#source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/dicom2bids_tutorial.md
+++ b/docs/dicom2bids_tutorial.md
@@ -58,10 +58,10 @@ Open clpipe_config.json and navigate to the "DICOMToBIDSOptions":
 
 This section tells clpipe how to run your BIDS conversion. Note that clpipe has been automatically configured to point to your DICOM directory, "DICOMDirectory", which will serve as the input to the dcm2bids command. The output folder, "BIDSDirectory", is also already set. These can be modified to point to new locations if necessary - for example, you may want to create more than one BIDS directory for testing purposes.
 
-The option "DICOMFormatString" must be set to run your bids conversion. This configuration tells clpipe how to identify subjects and (if relevant) sessions within `data_DICOMs`. To pick up on the subject ids in our example dataset, the placeholder `{subject}` should be given in place of a specific subject's directory:
+The option "DICOMFormatString" must be set to run your bids conversion. This configuration tells clpipe how to identify subjects and (if relevant) sessions within `data_DICOMs`. To pick up on the subject ids in our example dataset, the placeholder `{subject}` should be given in place of a specific subject's directory. The subject ID cannot contain underscores, so we will include the `mr_` portion of the subject folder name before the `{subject}` placeholder to exclude it from the subject's generated id:
 
 ```
-"DICOMFormatString": "dcm_qa_nih/In/20180918GE/{subject}"
+"DICOMFormatString": "dcm_qa_nih/In/20180918GE/mr_{subject}"
 ```
 
 If your data contained an addtional folder layer corresponding to session ids, you would similarily mark this with a `{session}` placeholder
@@ -115,9 +115,9 @@ clpipe will then print out a "plan" for executing your jobs:
 
 ```
 dcm_qa_nih/In/20180918GE/*
-/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/{subject}/
-sbatch --no-requeue -n 1 --mem=5000 --time=1:0:0 --cpus-per-task=2 --job-name="convert_sub-mr_0004" --output=/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project/logs/DCM2BIDS_logs/Output-convert_sub-mr_0004-jobid-%j.out --wrap="dcm2bids -d <your system's path>/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/mr_0004/ -o <your system's path>/clpipe/clpipe_tutorial_project/data_BIDS -p mr_0004 -c <your system's path>/clpipe_tutorial_project/conversion_config.json"
-sbatch --no-requeue -n 1 --mem=5000 --time=1:0:0 --cpus-per-task=2 --job-name="convert_sub-mr_0005" --output=<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs/Output-convert_sub-mr_0005-jobid-%j.out --wrap="dcm2bids -d <your system's path>clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/mr_0005/ -o <your system's path>/clpipe_tutorial_project/data_BIDS -p mr_0005 -c <your system's path>/clpipe_tutorial_project/conversion_config.json"
+<your system's path>/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/{subject}/
+sbatch --no-requeue -n 1 --mem=5000 --time=1:0:0 --cpus-per-task=2 --job-name="convert_sub-0004" --output=<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs/Output-convert_sub-0004-jobid-%j.out --wrap="dcm2bids -d <your system's path>/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/0004/ -o <your system's path>/clpipe/clpipe_tutorial_project/data_BIDS -p 0004 -c <your system's path>/clpipe_tutorial_project/conversion_config.json"
+sbatch --no-requeue -n 1 --mem=5000 --time=1:0:0 --cpus-per-task=2 --job-name="convert_sub-0005" --output=<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs/Output-convert_sub-0005-jobid-%j.out --wrap="dcm2bids -d <your system's path>clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/0005/ -o <your system's path>/clpipe_tutorial_project/data_BIDS -p 0005 -c <your system's path>/clpipe_tutorial_project/conversion_config.json"
 ...
 ```
 
@@ -133,7 +133,7 @@ clpipe should then report that you have submitted 4 jobs to the cluster:
 
 ```
 dcm_qa_nih/In/20180918GE/*
-/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/{subject}/
+<your system's path>/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/mr_{subject}/
 Submitted batch job 38210854
 Submitted batch job 38210855
 Submitted batch job 38210856
@@ -152,14 +152,14 @@ Now, your BIDS directory should look something like this:
 ├── participants.tsv
 ├── README
 ├── sourcedata
-├── sub-mr_0004
+├── sub-0004
 │   └── func
-│       ├── sub-mr_0004_task-rest_bold.json
-│       └── sub-mr_0004_task-rest_bold.nii.gz
+│       ├── sub-0004_task-rest_bold.json
+│       └── sub-0004_task-rest_bold.nii.gz
 └── tmp_dcm2bids
 ```
 
-But wait a second! You were expecting four subjects to be in your BIDS directory, but only `sub-mr_0004` is present. The next section will guide you through how to tune your `conversion_config.json` file to pick up all of the images you need.
+But wait a second! You were expecting four subjects to be in your BIDS directory, but only `sub-0004` is present. The next section will guide you through how to tune your `conversion_config.json` file to pick up all of the images you need.
 
 ## Iterating on Your Conversion
 
@@ -170,20 +170,20 @@ The folder `tmp_dcm2bids` contains all of the images that were not matched to an
 ```
 └── tmp_dcm2bids
     ├── log
-    │   ├── sub-mr_0004_2022-02-17T103129.039268.log
-    │   ├── sub-mr_0005_2022-02-17T103129.116426.log
-    │   ├── sub-mr_0006_2022-02-17T103129.082788.log
-    │   └── sub-mr_0007_2022-02-17T103129.191004.log
-    ├── sub-mr_0004
-    ├── sub-mr_0005
-    │   ├── 005_mr_0005_Axial_EPI-FMRI_(Sequential_I_to_S)_20180918114023.json
-    │   └── 005_mr_0005_Axial_EPI-FMRI_(Sequential_I_to_S)_20180918114023.nii.gz
-    ├── sub-mr_0006
-    │   ├── 006_mr_0006_Axial_EPI-FMRI_(Interleaved_S_to_I)_20180918114023.json
-    │   └── 006_mr_0006_Axial_EPI-FMRI_(Interleaved_S_to_I)_20180918114023.nii.gz
-    └── sub-mr_0007
-        ├── 007_mr_0007_Axial_EPI-FMRI_(Sequential_S_to_I)_20180918114023.json
-        └── 007_mr_0007_Axial_EPI-FMRI_(Sequential_S_to_I)_20180918114023.nii.gz
+    │   ├── sub-0004_2022-02-17T103129.039268.log
+    │   ├── sub-0005_2022-02-17T103129.116426.log
+    │   ├── sub-0006_2022-02-17T103129.082788.log
+    │   └── sub-0007_2022-02-17T103129.191004.log
+    ├── sub-0004
+    ├── sub-0005
+    │   ├── 005_0005_Axial_EPI-FMRI_(Sequential_I_to_S)_20180918114023.json
+    │   └── 005_0005_Axial_EPI-FMRI_(Sequential_I_to_S)_20180918114023.nii.gz
+    ├── sub-0006
+    │   ├── 006_0006_Axial_EPI-FMRI_(Interleaved_S_to_I)_20180918114023.json
+    │   └── 006_0006_Axial_EPI-FMRI_(Interleaved_S_to_I)_20180918114023.nii.gz
+    └── sub-0007
+        ├── 007_0007_Axial_EPI-FMRI_(Sequential_S_to_I)_20180918114023.json
+        └── 007_0007_Axial_EPI-FMRI_(Sequential_S_to_I)_20180918114023.nii.gz
 ```
 
 As the raw data folder we have pointed clpipe toward, `20180918GE`, contains functional data, we will look at the `"func"` list item in our `conversion_config.json` to adjust:
@@ -227,22 +227,22 @@ Now, all subjects should be present in your BIDS directory along with their rest
 
 ```
 ...
-├── sub-mr_0004
+├── sub-0004
 │   └── func
-│       ├── sub-mr_0004_task-rest_bold.json
-│       └── sub-mr_0004_task-rest_bold.nii.gz
-├── sub-mr_0005
+│       ├── sub-0004_task-rest_bold.json
+│       └── sub-0004_task-rest_bold.nii.gz
+├── sub-0005
 │   └── func
-│       ├── sub-mr_0005_task-rest_bold.json
-│       └── sub-mr_0005_task-rest_bold.nii.gz
-├── sub-mr_0006
+│       ├── sub-0005_task-rest_bold.json
+│       └── sub-0005_task-rest_bold.nii.gz
+├── sub-0006
 │   └── func
-│       ├── sub-mr_0006_task-rest_bold.json
-│       └── sub-mr_0006_task-rest_bold.nii.gz
-├── sub-mr_0007
+│       ├── sub-0006_task-rest_bold.json
+│       └── sub-0006_task-rest_bold.nii.gz
+├── sub-0007
 │   └── func
-│       ├── sub-mr_0007_task-rest_bold.json
-│       └── sub-mr_0007_task-rest_bold.nii.gz
+│       ├── sub-0007_task-rest_bold.json
+│       └── sub-0007_task-rest_bold.nii.gz
 └── tmp_dcm2bids
 ```
 
@@ -260,7 +260,7 @@ We can point clpipe to this additional data by modifying the `clpipe_config.json
 	"DICOMDirectory": "<your system's path>/clpipe_tutorial_project/data_DICOMs",
 	"BIDSDirectory": "<your system's path>/clpipe_tutorial_project/data_BIDS",
 	"ConversionConfig": "<your system's path>/clpipe_tutorial_project/conversion_config.json",
-	"DICOMFormatString": "dcm_qa_nih/In/20180918Si/{subject}",
+	"DICOMFormatString": "dcm_qa_nih/In/20180918Si/mr_{subject}",
 	"TimeUsage": "1:0:0",
 	"MemUsage": "5000",
 	"CoreUsage": "2",
@@ -271,27 +271,28 @@ We can point clpipe to this additional data by modifying the `clpipe_config.json
 We pick up a new subject this way:
 
 ```
-├── sub-mr_0003
+├── sub-0003
 │   └── fmap
-│       ├── sub-mr_0003_dir-AP_epi.json
-│       └── sub-mr_0003_dir-AP_epi.nii.gz
+│       ├── sub-0003_dir-AP_epi.json
+│       └── sub-0003_dir-AP_epi.nii.gz
 ```
 
 However, our tmp_dcm2bids now contains more images that were not picked up. The images with "EPI" in the title are the field maps that our critera did not match:
 
 ```
-├── sub-mr_0004
-    │   ├── 004_mr_0004_Axial_EPI-FMRI_(Interleaved_I_to_S)_20180918114023.json
-    │   └── 004_mr_0004_Axial_EPI-FMRI_(Interleaved_I_to_S)_20180918114023.nii.gz
-    ├── sub-mr_0005
-    │   ├── 005_mr_0005_EPI_PE=RL_20180918121230.json
-    │   └── 005_mr_0005_EPI_PE=RL_20180918121230.nii.gz
-    ├── sub-mr_0006
-    │   ├── 006_mr_0006_EPI_PE=LR_20180918121230.json
-    │   └── 006_mr_0006_EPI_PE=LR_20180918121230.nii.gz
+├── tmp_dcm2bids	
+	├── sub-0004
+    │   ├── 004_0004_Axial_EPI-FMRI_(Interleaved_I_to_S)_20180918114023.json
+    │   └── 004_0004_Axial_EPI-FMRI_(Interleaved_I_to_S)_20180918114023.nii.gz
+    ├── sub-0005
+    │   ├── 005_0005_EPI_PE=RL_20180918121230.json
+    │   └── 005_0005_EPI_PE=RL_20180918121230.nii.gz
+    ├── sub-0006
+    │   ├── 006_0006_EPI_PE=LR_20180918121230.json
+    │   └── 006_0006_EPI_PE=LR_20180918121230.nii.gz
 ```
 
-Like our last iteration, we can adjust the conversion_config.json file to pick up these images. However, the two fmap critera we have already are properly picking up on the AP/PA field maps. Create two new critera to match the field maps found in `sub-mr_0005` and `sub-mr_0006`, one from LR and another for RL:
+Like our last iteration, we can adjust the conversion_config.json file to pick up these images. However, the two fmap critera we have already are properly picking up on the AP/PA field maps. Create two new critera to match the field maps found in `sub-0005` and `sub-0006`, one from LR and another for RL:
 
 ```
 {
@@ -316,21 +317,23 @@ Like our last iteration, we can adjust the conversion_config.json file to pick u
 
 > Note: The "intendedFor" field points the fieldmap critera to the index of its corresponding functional image critera. In this case, we only have one functional image critera, for the resting state image, which is listed first (index 0). Therefore, it is important that the resting image critera stays first in the list; otherwise, these indexes would need to be updated.
 
-After running the conversion again, you should now see that `sub-mr_0005` and `sub-mr_0006` have fieldmap images in addition to their functional scans:
+After running the conversion again, you should now see that `sub-0005` and `sub-0006` have fieldmap images in addition to their functional scans:
 
 ```
-├── sub-mr_0005
+├── sub-0005
 │   ├── fmap
-│   │   ├── sub-mr_0005_dir-RL_epi.json
-│   │   └── sub-mr_0005_dir-RL_epi.nii.gz
+│   │   ├── sub-0005_dir-RL_epi.json
+│   │   └── sub-0005_dir-RL_epi.nii.gz
 │   └── func
-│       ├── sub-mr_0005_task-rest_bold.json
-│       └── sub-mr_0005_task-rest_bold.nii.gz
-├── sub-mr_0006
+│       ├── sub-0005_task-rest_bold.json
+│       └── sub-0005_task-rest_bold.nii.gz
+├── sub-0006
 │   ├── fmap
-│   │   ├── sub-mr_0006_dir-LR_epi.json
-│   │   └── sub-mr_0006_dir-LR_epi.nii.gz
+│   │   ├── sub-0006_dir-LR_epi.json
+│   │   └── sub-0006_dir-LR_epi.nii.gz
 │   └── func
-│       ├── sub-mr_0006_task-rest_bold.json
-│       └── sub-mr_0006_task-rest_bold.nii.gz
+│       ├── sub-0006_task-rest_bold.json
+│       └── sub-0006_task-rest_bold.nii.gz
 ```
+
+Great! However, this BIDS directory is not finished quite yet - next we will use the BIDS validator tool to detect the problems with our BIDS directory.

--- a/docs/dicom2bids_tutorial.md
+++ b/docs/dicom2bids_tutorial.md
@@ -1,0 +1,336 @@
+# BIDS Conversion
+
+The goal of this processing step is to convert "raw" DICOM format images into BIDS format. If your data is already in BIDS format, move on to the BIDS Validation step.
+
+Due to the manual labeling necessary for DICOM to BIDS conversion, this is one of the most difficult parts of clpipe to setup - do not be discourged by this early step!
+
+> Note: This tutorial is a clpipe implmentation of the [dcm2bids](https://unfmontreal.github.io/Dcm2Bids/docs/2-tutorial/) tutorial, which clpipe uses for dcm to BIDS conversion.
+
+## Obtaining Sample Raw Data
+
+To obtain the raw DICOM data necessary for this tutorial, run the following commands:
+
+```
+cd data_DICOMs
+git clone git@github.com:neurolabusc/dcm_qa_nih.git
+cd ..
+```
+
+Let's examine this data:
+
+```
+dcm_qa_nih/In/
+├── 20180918GE
+│   ├── mr_0004
+│   ├── mr_0005
+│   ├── mr_0006
+│   ├── mr_0007
+│   └── README-Study.txt
+└── 20180918Si
+ ├── mr_0003
+ ├── mr_0004
+ ├── mr_0005
+ ├── mr_0006
+ └── README-Study.txt
+```
+
+This dataset contains two sets of data, one from a GE scanner, containing functional images, and another from a Siemens, containing field map images. The labels in the form `mr_000x` are subject ids, which will be important for setting up our bids conversion.
+
+> Note: The BIDS data generated in this step will also be used in the BIDS Validation tutorial, but tutorials starting from fMRIprep and on we will use a different BIDS dataset
+
+
+## clpipe_config.json Setup
+
+Open clpipe_config.json and navigate to the "DICOMToBIDSOptions":
+
+```
+"DICOMToBIDSOptions": {
+	"DICOMDirectory": "<your system's path>/clpipe_tutorial_project/data_DICOMs",
+	"BIDSDirectory": "<your system's path>/clpipe_tutorial_project/data_BIDS",
+	"ConversionConfig": "<your system's path>/clpipe_tutorial_project/conversion_config.json",
+	"DICOMFormatString": "",
+	"TimeUsage": "1:0:0",
+	"MemUsage": "5000",
+	"CoreUsage": "2",
+	"LogDirectory": "<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs"
+}
+```
+
+This section tells clpipe how to run your BIDS conversion. Note that clpipe has been automatically configured to point to your DICOM directory, "DICOMDirectory", which will serve as the input to the dcm2bids command. The output folder, "BIDSDirectory", is also already set. These can be modified to point to new locations if necessary - for example, you may want to create more than one BIDS directory for testing purposes.
+
+The option "DICOMFormatString" must be set to run your bids conversion. This configuration tells clpipe how to identify subjects and (if relevant) sessions within `data_DICOMs`. To pick up on the subject ids in our example dataset, the placeholder `{subject}` should be given in place of a specific subject's directory:
+
+```
+"DICOMFormatString": "dcm_qa_nih/In/20180918GE/{subject}"
+```
+
+If your data contained an addtional folder layer corresponding to session ids, you would similarily mark this with a `{session}` placeholder
+
+The "ConversionConfig" command gives a path to your automatically generated conversion_config.json file. Let's open that file now:
+
+```
+{
+	"descriptions": [
+		{
+			"dataType": "func",
+			"modalityLabel": "bold",
+			"customLabels": "task-srt",
+			"criteria": {
+				"SeriesDescription": "*_srt",
+				"ImageType": [
+					"ORIG*",
+					"PRIMARY",
+					"M",
+					"ND",
+					"MOSAIC"
+				]
+			}
+		}
+	]
+}
+```
+The conversion file contains a list of descriptions, each of which attempts to map raw DICOM images to a given critera. clpipe has prepopulated the conversion config file with an example description.
+
+The "critera" item gives a list of critera by which to match DICOM images. The other tags specify the format of the output NIfTI image that match this critera. "dataType" and "modalityLabel" configure the name of your output
+
+More information on setting up clpipe for BIDS conversion can be found in the [clpipe documentation](https://clpipe.readthedocs.io/en/latest/dicom2bids.html#).
+
+
+## Setting up the Conversion File
+From here, follow the [Dcm2Bids tutorial](https://unfmontreal.github.io/Dcm2Bids/docs/2-tutorial/#dicom-to-nifti-conversion) and stop before the "Running dcm2bids" section - clpipe will handling running dcm2bids for you. The helper command `dcm2bids_helper` will be available to you via the clpipe installation, and should be used as indicated in the tutorial to help you get started. You should also skip the "Building the configuration file" step because, as shown above, clpipe has already created this file.
+
+You can find a supplentary explanation and another example of a conversion_config.json file in the [clpipe documentation](https://clpipe.readthedocs.io/en/latest/dicom2bids.html#)
+
+
+## Running the Conversion
+Now you are ready to launch the conversion with clpipe, which will convert your raw DICOMs into NIfTI format, then rename and sort them into the BIDS standard.
+
+If everything has been set up correctly, running the conversion only takes a simple call to the [CLI application](https://clpipe.readthedocs.io/en/latest/dicom2bids.html#conversion-commands) with the configuration file as an argument:
+
+```
+convert2bids -config_file clpipe_config.json
+```
+
+clpipe will then print out a "plan" for executing your jobs:
+
+```
+dcm_qa_nih/In/20180918GE/*
+/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/{subject}/
+sbatch --no-requeue -n 1 --mem=5000 --time=1:0:0 --cpus-per-task=2 --job-name="convert_sub-mr_0004" --output=/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project/logs/DCM2BIDS_logs/Output-convert_sub-mr_0004-jobid-%j.out --wrap="dcm2bids -d <your system's path>/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/mr_0004/ -o <your system's path>/clpipe/clpipe_tutorial_project/data_BIDS -p mr_0004 -c <your system's path>/clpipe_tutorial_project/conversion_config.json"
+sbatch --no-requeue -n 1 --mem=5000 --time=1:0:0 --cpus-per-task=2 --job-name="convert_sub-mr_0005" --output=<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs/Output-convert_sub-mr_0005-jobid-%j.out --wrap="dcm2bids -d <your system's path>clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/mr_0005/ -o <your system's path>/clpipe_tutorial_project/data_BIDS -p mr_0005 -c <your system's path>/clpipe_tutorial_project/conversion_config.json"
+...
+```
+
+Each `sbatch` command here will submit a separate job to the cluster.
+
+Check that your output looks correct, especially the subject ids, then run again with the `-submit` flag to run your conversions in parallel:
+
+```
+convert2bids -config_file clpipe_config.json -submit
+```
+
+clpipe should then report that you have submitted 4 jobs to the cluster:
+
+```
+dcm_qa_nih/In/20180918GE/*
+/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project/data_DICOMs/dcm_qa_nih/In/20180918GE/{subject}/
+Submitted batch job 38210854
+Submitted batch job 38210855
+Submitted batch job 38210856
+Submitted batch job 38210857
+```
+
+
+Now, your BIDS directory should look something like this:
+
+```
+├── CHANGES
+├── code
+├── dataset_description.json
+├── derivatives
+├── participants.json
+├── participants.tsv
+├── README
+├── sourcedata
+├── sub-mr_0004
+│   └── func
+│       ├── sub-mr_0004_task-rest_bold.json
+│       └── sub-mr_0004_task-rest_bold.nii.gz
+└── tmp_dcm2bids
+```
+
+But wait a second! You were expecting four subjects to be in your BIDS directory, but only `sub-mr_0004` is present. The next section will guide you through how to tune your `conversion_config.json` file to pick up all of the images you need.
+
+## Iterating on Your Conversion
+
+Inevitably, you will probably not get the conversion completely correct on the first try, and some files may have been missed.
+
+The folder `tmp_dcm2bids` contains all of the images that were not matched to any of the patterns described in your `conversion_config.json` file, as well as helpful log files:
+
+```
+└── tmp_dcm2bids
+    ├── log
+    │   ├── sub-mr_0004_2022-02-17T103129.039268.log
+    │   ├── sub-mr_0005_2022-02-17T103129.116426.log
+    │   ├── sub-mr_0006_2022-02-17T103129.082788.log
+    │   └── sub-mr_0007_2022-02-17T103129.191004.log
+    ├── sub-mr_0004
+    ├── sub-mr_0005
+    │   ├── 005_mr_0005_Axial_EPI-FMRI_(Sequential_I_to_S)_20180918114023.json
+    │   └── 005_mr_0005_Axial_EPI-FMRI_(Sequential_I_to_S)_20180918114023.nii.gz
+    ├── sub-mr_0006
+    │   ├── 006_mr_0006_Axial_EPI-FMRI_(Interleaved_S_to_I)_20180918114023.json
+    │   └── 006_mr_0006_Axial_EPI-FMRI_(Interleaved_S_to_I)_20180918114023.nii.gz
+    └── sub-mr_0007
+        ├── 007_mr_0007_Axial_EPI-FMRI_(Sequential_S_to_I)_20180918114023.json
+        └── 007_mr_0007_Axial_EPI-FMRI_(Sequential_S_to_I)_20180918114023.nii.gz
+```
+
+As the raw data folder we have pointed clpipe toward, `20180918GE`, contains functional data, we will look at the `"func"` list item in our `conversion_config.json` to adjust:
+
+```
+{
+	"dataType": "func",
+	"modalityLabel": "bold",
+	"customLabels": "task-rest",
+	"criteria": {
+		"SeriesDescription": "Axial_EPI-FMRI*",
+		"SidecarFilename": "*Interleaved_I_to_S*"
+	}
+}
+```
+
+Sidecars are .json files that have the same name as the `.nii.gz` main image file, and contain additional metadata for the image; they are part of the BIDS standard.
+
+This configuration is trying to match on a side car with the pattern `"*Interleaved_I_to_S*"`, but we can see in the `tmp_dcm2bids` folder that none of the subjects here match this pattern. If we want to pick up the remaining subjects, we can relax this critera by removing it from `conversion_config.json` :
+
+```
+{
+	"dataType": "func",
+	"modalityLabel": "bold",
+	"customLabels": "task-rest",
+	"criteria": {
+		"SeriesDescription": "Axial_EPI-FMRI*"
+	}
+}
+```
+
+> Note: Take special care to remove the comma following the "SeriesDescription" list item - using commas in a single-item list will result in invalid JSON that will cause an error
+
+And rerunning the conversion:
+
+```
+convert2bids -config_file clpipe_config.json -submit
+```
+
+Now, all subjects should be present in your BIDS directory along with their resting state images:
+
+```
+...
+├── sub-mr_0004
+│   └── func
+│       ├── sub-mr_0004_task-rest_bold.json
+│       └── sub-mr_0004_task-rest_bold.nii.gz
+├── sub-mr_0005
+│   └── func
+│       ├── sub-mr_0005_task-rest_bold.json
+│       └── sub-mr_0005_task-rest_bold.nii.gz
+├── sub-mr_0006
+│   └── func
+│       ├── sub-mr_0006_task-rest_bold.json
+│       └── sub-mr_0006_task-rest_bold.nii.gz
+├── sub-mr_0007
+│   └── func
+│       ├── sub-mr_0007_task-rest_bold.json
+│       └── sub-mr_0007_task-rest_bold.nii.gz
+└── tmp_dcm2bids
+```
+
+
+## Adding an Additional Data Source
+
+Our raw data folder at `data_DICOMs/dcm_qa_nih/In/20180918Si` contains additonal images for our sample study. These are field maps that correspond to our functional resting state images. 
+
+Due to the location of these field maps being in a separate folder from the functional data, they are a distinct source of data from the point of view of clpipe. Although we could combine the functional images and field maps into one folder, under their respective subjects, often we only want to read from source data.
+
+We can point clpipe to this additional data by modifying the `clpipe_config.json` to point to its path in `DICOMToBIDSOptions`, under `DICOMFormatString`:
+
+```
+"DICOMToBIDSOptions": {
+	"DICOMDirectory": "<your system's path>/clpipe_tutorial_project/data_DICOMs",
+	"BIDSDirectory": "<your system's path>/clpipe_tutorial_project/data_BIDS",
+	"ConversionConfig": "<your system's path>/clpipe_tutorial_project/conversion_config.json",
+	"DICOMFormatString": "dcm_qa_nih/In/20180918Si/{subject}",
+	"TimeUsage": "1:0:0",
+	"MemUsage": "5000",
+	"CoreUsage": "2",
+	"LogDirectory": "<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs"
+}
+```
+
+We pick up a new subject this way:
+
+```
+├── sub-mr_0003
+│   └── fmap
+│       ├── sub-mr_0003_dir-AP_epi.json
+│       └── sub-mr_0003_dir-AP_epi.nii.gz
+```
+
+However, our tmp_dcm2bids now contains more images that were not picked up. The images with "EPI" in the title are the field maps that our critera did not match:
+
+```
+├── sub-mr_0004
+    │   ├── 004_mr_0004_Axial_EPI-FMRI_(Interleaved_I_to_S)_20180918114023.json
+    │   └── 004_mr_0004_Axial_EPI-FMRI_(Interleaved_I_to_S)_20180918114023.nii.gz
+    ├── sub-mr_0005
+    │   ├── 005_mr_0005_EPI_PE=RL_20180918121230.json
+    │   └── 005_mr_0005_EPI_PE=RL_20180918121230.nii.gz
+    ├── sub-mr_0006
+    │   ├── 006_mr_0006_EPI_PE=LR_20180918121230.json
+    │   └── 006_mr_0006_EPI_PE=LR_20180918121230.nii.gz
+```
+
+Like our last iteration, we can adjust the conversion_config.json file to pick up these images. However, the two fmap critera we have already are properly picking up on the AP/PA field maps. Create two new critera to match the field maps found in `sub-mr_0005` and `sub-mr_0006`, one from LR and another for RL:
+
+```
+{
+	"dataType": "fmap",
+	"modalityLabel": "epi",
+	"customLabels": "dir-RL",
+	"criteria": {
+		"SidecarFilename": "*EPI_PE=RL*"
+	},
+	"intendedFor": 0
+},
+{
+	"dataType": "fmap",
+	"modalityLabel": "epi",
+	"customLabels": "dir-LR",
+	"criteria": {
+		"SidecarFilename": "*EPI_PE=LR*"
+	},
+	"intendedFor": 0
+}
+```
+
+> Note: The "intendedFor" field points the fieldmap critera to the index of its corresponding functional image critera. In this case, we only have one functional image critera, for the resting state image, which is listed first (index 0). Therefore, it is important that the resting image critera stays first in the list; otherwise, these indexes would need to be updated.
+
+After running the conversion again, you should now see that `sub-mr_0005` and `sub-mr_0006` have fieldmap images in addition to their functional scans:
+
+```
+├── sub-mr_0005
+│   ├── fmap
+│   │   ├── sub-mr_0005_dir-RL_epi.json
+│   │   └── sub-mr_0005_dir-RL_epi.nii.gz
+│   └── func
+│       ├── sub-mr_0005_task-rest_bold.json
+│       └── sub-mr_0005_task-rest_bold.nii.gz
+├── sub-mr_0006
+│   ├── fmap
+│   │   ├── sub-mr_0006_dir-LR_epi.json
+│   │   └── sub-mr_0006_dir-LR_epi.nii.gz
+│   └── func
+│       ├── sub-mr_0006_task-rest_bold.json
+│       └── sub-mr_0006_task-rest_bold.nii.gz
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ clpipe was developed to streamline the processing of MRI data using the high per
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
+   :caption: Documentation
 
    install
    project_setup
@@ -28,7 +28,7 @@ clpipe was developed to streamline the processing of MRI data using the high per
 
 .. toctree::
    :maxdepth: 1
-   :caption: Tutorial:
+   :caption: Tutorial
 
    install_tutorial
    dicom2bids_tutorial

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,4 +32,5 @@ clpipe was developed to streamline the processing of MRI data using the high per
 
    install_tutorial
    dicom2bids_tutorial
+   bids_validation_tutorial
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Welcome to clpipe: A MRI Processing Pipeline for high performance clusters!
 clpipe was developed to streamline the processing of MRI data using the high performance cluster at University of North Carolina at Chapel Hill. It uses `fmriprep <https://fmriprep.readthedocs.io/en/stable/>`_ for preprocessing fMRI data and implements a variety of additional processing steps important for functional connectivity analyses such as nuisance regression and filtering. Also included in clpipe are a variety of console commands for validation and checking the results of preprocessing. Please report any bugs, issues or feature requests on our `Github page <https://github.com/cohenlabUNC/clpipe>`_.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Contents:
 
    install
@@ -25,4 +25,11 @@ clpipe was developed to streamline the processing of MRI data using the high per
    susan
    roi_extraction
    glm
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tutorial:
+
+   install_tutorial
+   dicom2bids_tutorial
 

--- a/docs/install_tutorial.md
+++ b/docs/install_tutorial.md
@@ -1,0 +1,119 @@
+# Project Setup
+
+## Installation and Folder Setup
+
+First, [install clpipe](https://clpipe.readthedocs.io/en/latest/install.html) using pip and Github
+
+```
+pip3 install --upgrade git+git://github.com/cohenlabUNC/clpipe
+```
+
+Create a new folder for your project
+
+```
+mkdir clpipe_tutorial_project
+cd clpipe_tutorial_project
+```
+
+Running project setup requires us to have a source data directory ready. Create an empty one for now
+
+```
+mkdir data_DICOMs
+```
+
+Now you are ready to run the [project_setup](https://clpipe.readthedocs.io/en/latest/project_setup.html) command
+
+## Running project_setup
+
+```
+project_setup -project_title clpipe_tutorial_project -project_dir . -source_data data_DICOMs
+```
+
+If successful, your folder will now contain the following structure:
+
+```      
+.
+├── analyses
+├── clpipe_config.json
+├── conversion_config.json
+├── data_BIDS
+├── data_DICOMs
+├── data_fmriprep
+├── data_GLMPrep
+├── data_onsets
+├── data_postproc
+├── data_ROI_ts
+├── glm_config.json
+├── l1_feat_folders
+├── l1_fsfs
+├── l2_fsfs
+├── l2_gfeat_folders
+├── l2_sublist.csv
+├── logs
+└── scripts
+```
+
+clpipe automatically creates many of the directories we will need in the future. For now, let's just familiarize ourself with the most import file, `clpipe_config.json`, which allows you to configure clpipe's core functionalities. Open `clpipe_config.json` with the editor of your choice.
+
+## Understanding the clpipe_config.json File
+
+There is quite a bit going on in this file, because it controls most of clpipe's processing options. As a `.json` file, this configuration is organized as a collection of key/value pairs, such as:
+
+```
+"ProjectTitle": "A Neuroimaging Project"
+```
+
+The key here is "ProjectTitle", an attribute corresponding to the project's name, and the value is "A Neuroimaging Project", the name of the project.
+
+Examine the first few lines of the file, which contain metadata about your project:
+
+```
+"ProjectTitle": "clpipe_tutorial_project",
+"Authors/Contributors": "",
+"ProjectDirectory": "<your system's path>/clpipe_tutorial_project",
+"EmailAddress": "",
+"TempDirectory": "",
+```
+
+Notice that the project directory and title have already been filled in by clpipe.
+
+Let's make our first configuration change by setting your name as the author, and providing your email address -
+
+```
+"ProjectTitle": "clpipe_tutorial_project",
+"Authors/Contributors": "Your Name Here",
+"ProjectDirectory": "/nas/longleaf/home/willasc/data/clpipe/clpipe_tutorial_project",
+"EmailAddress": "myemail@domain.com",
+"TempDirectory": "",
+```
+
+Values in a key/value pair are not just limited to text - we can also have a list of more key/value pairs, which allows for hierarchial structures:
+
+```
+"top-level-key": {
+	"key1":"value",
+	"key2":"value",
+	"key3":"value"
+}
+```
+
+The options for clpipe's various processing steps, such as "DICOMToBIDSOptions", follow this structure:
+
+```
+"DICOMToBIDSOptions": {
+	       
+
+"DICOMToBIDSOptions": {
+ "DICOMDirectory": "<your system's path>/clpipe_tutorial_project/data_DICOMs",
+ "BIDSDirectory": "<your system's path>/clpipe_tutorial_project/data_BIDS",
+ "ConversionConfig": "<your system's path>/clpipe_tutorial_project/conversion_config.json",
+ "DICOMFormatString": "",
+ "TimeUsage": "1:0:0",
+ "MemUsage": "5000",
+ "CoreUsage": "2",
+ "LogDirectory": "<your system's path>/clpipe_tutorial_project/logs/DCM2BIDS_logs"
+ }
+}
+```
+
+We will go over these processing step options in the following tutorial

--- a/docs/install_tutorial.md
+++ b/docs/install_tutorial.md
@@ -5,7 +5,7 @@
 First, [install clpipe](https://clpipe.readthedocs.io/en/latest/install.html) using pip and Github
 
 ```
-pip3 install --upgrade git+git://github.com/cohenlabUNC/clpipe
+pip3 install --upgrade git+https://github.com/cohenlabUNC/clpipe.git
 ```
 
 Create a new folder for your project

--- a/docs/tutorial_index.md
+++ b/docs/tutorial_index.md
@@ -1,4 +1,0 @@
-# Clpipe Tutorial
-
-[Project Setup](docs/dicom2bids_tutorial.md)
-[dicom2bids](docs/install_tutorial.md)

--- a/docs/tutorial_index.md
+++ b/docs/tutorial_index.md
@@ -1,0 +1,4 @@
+# Clpipe Tutorial
+
+[Project Setup](docs/dicom2bids_tutorial.md)
+[dicom2bids](docs/install_tutorial.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 pytest
 wheel
+
+# Documentation builder tools
+sphinx
+myst-parser
+sphinx-jsonschema
 -e .


### PR DESCRIPTION
Provides a tutorial guiding a clpipe user from project setup through BIDS Validation using a publicly available dataset (the one used by dcm2bids)

<img width="294" alt="image" src="https://user-images.githubusercontent.com/34407871/160004615-0b5f2222-0147-4d3c-8293-a14d6e37be6d.png">

<img width="760" alt="image" src="https://user-images.githubusercontent.com/34407871/160004895-d8bae1f5-3260-47b6-a579-b61abd424072.png">
