### PR TITLE
Release 1.4.2

### DIFF
--- a/clpipe/bids_validator.py
+++ b/clpipe/bids_validator.py
@@ -8,27 +8,29 @@ from .config_json_parser import ClpipeConfigParser
 
 
 @click.command()
-@click.option('-config_file', type=click.Path(exists=True, dir_okay=False, file_okay=True), default=None, help = 'Uses a given configuration file')
 @click.argument('bids_dir', type=click.Path(exists=True, dir_okay=True, file_okay=False), required=False)
+@click.option('-config_file', type=click.Path(exists=True, dir_okay=False, file_okay=True), default=None, help = 'Uses a given configuration file')
+@click.option('-log_dir', type=click.Path(exists=True, dir_okay=False, file_okay=True), default=None, help = 'Set the log output path.')
 @click.option('-verbose', is_flag = True, default=False, help = 'Creates verbose validator output. Use if you want to see ALL files with errors/warnings.')
 @click.option('-submit', is_flag = True, help = 'Submit command to HPC.')
 @click.option('-interactive', is_flag = True, default=False, help = 'Run in an interactive session. Only use in an interactive compute session.')
 @click.option('-debug', is_flag=True, help = 'Produce detailed debug and traceback.')
-def bids_validate_cli(bids_dir, config_file, interactive, submit, verbose, debug):
-    bids_validate(bids_dir=bids_dir, config_file=config_file, interactive=interactive, submit=submit, verbose=verbose, debug=debug)
+def bids_validate_cli(bids_dir, config_file, log_dir, interactive, submit, verbose, debug):
+    bids_validate(bids_dir=bids_dir, config_file=config_file, log_dir=log_dir, interactive=interactive, submit=submit, verbose=verbose, debug=debug)
 
-def bids_validate(bids_dir=None, config_file=None, interactive=False, submit=True, verbose=False, debug=False):
+def bids_validate(bids_dir=None, config_file=None, log_dir=None, interactive=False, submit=True, verbose=False, debug=False):
     """Runs the BIDS-Validator program on a dataset. If a configuration file has a BIDSDirectory specified, you do not need to provide a BIDS directory in the command."""
     if not debug:
         sys.excepthook = exception_handler
     config = ClpipeConfigParser()
     config.config_updater(config_file)
+    config.setup_bids_validation(log_dir)
     config.setup_fmriprep_directories(bids_dir, None, None)
 
     if bids_dir is None and config_file is None:
         raise ValueError('Specify a BIDS directory in either the configuration file, or in the command')
 
-    batch_manager = BatchManager(batchsystemConfig=config.config['BatchConfig'])
+    batch_manager = BatchManager(batchsystemConfig=config.config['BatchConfig'], outputDirectory=config.config['BIDSValidationOptions']['LogDirectory'])
     batch_manager.update_mem_usage('3000')
 
     singularity_string = '''singularity run --cleanenv -B {bindPaths} {validatorInstance} {bidsDir}'''

--- a/clpipe/config_json_parser.py
+++ b/clpipe/config_json_parser.py
@@ -66,6 +66,7 @@ class ClpipeConfigParser:
                             os.path.join(self.config['ProjectDirectory'], 'conversion_config.json'),
                             os.path.join(self.config['ProjectDirectory'], 'data_BIDS'),
                             None)
+        self.setup_bids_validation(None)
         self.setup_fmriprep_directories(os.path.join(self.config['ProjectDirectory'], 'data_BIDS'),
                                         None, os.path.join(self.config['ProjectDirectory'], 'data_fmriprep'))
         self.setup_postproc(os.path.join(self.config['FMRIPrepOptions']['OutputDirectory'], 'fmriprep'),
@@ -188,6 +189,13 @@ class ClpipeConfigParser:
         else:
             self.config['DICOMToBIDSOptions']['LogDirectory'] = os.path.join(self.config['ProjectDirectory'], 'logs', 'DCM2BIDS_logs')
         os.makedirs(self.config['DICOMToBIDSOptions']['LogDirectory'], exist_ok=True)
+
+    def setup_bids_validation(self, log_dir=None):
+        if log_dir is not None:
+            self.config['BIDSValidationOptions']['LogDirectory'] = os.path.abspath(log_dir)
+        else:
+            self.config['BIDSValidationOptions']['LogDirectory'] = os.path.join(self.config['ProjectDirectory'], 'logs', 'bids_validation_logs')
+        os.makedirs(self.config['BIDSValidationOptions']['LogDirectory'], exist_ok=True)
 
     def setup_roiextract(self, target_dir, target_suffix, output_dir, log_dir = None):
         if target_dir is not None:

--- a/clpipe/config_json_parser.py
+++ b/clpipe/config_json_parser.py
@@ -190,6 +190,13 @@ class ClpipeConfigParser:
             self.config['DICOMToBIDSOptions']['LogDirectory'] = os.path.join(self.config['ProjectDirectory'], 'logs', 'DCM2BIDS_logs')
         os.makedirs(self.config['DICOMToBIDSOptions']['LogDirectory'], exist_ok=True)
 
+        # Create a default .bidsignore file
+        bids_ignore_path = os.path.join(self.config['DICOMToBIDSOptions']['BIDSDirectory'], ".bidsignore")
+        if not os.path.exists(bids_ignore_path):
+            with open(bids_ignore_path, 'w') as bids_ignore_file:
+                # Ignore dcm2bid's auto-generated directory
+                bids_ignore_file.write("tmp_dcm2bids")
+
     def setup_bids_validation(self, log_dir=None):
         if log_dir is not None:
             self.config['BIDSValidationOptions']['LogDirectory'] = os.path.abspath(log_dir)

--- a/clpipe/data/defaultConfig.json
+++ b/clpipe/data/defaultConfig.json
@@ -23,6 +23,7 @@
 		"OutputDirectory": "",
 		"FMRIPrepPath": "/proj/hng/singularity_imgs/fmriprep-20.2.1.simg",
 		"FreesurferLicensePath": "/proj/hng/singularity_imgs/license.txt",
+		"UseAROMA": false,
 		"CommandLineOpts": "",
 		"TemplateFlowToggle": true,
 		"TemplateFlowPath": "",

--- a/clpipe/data/defaultConfig.json
+++ b/clpipe/data/defaultConfig.json
@@ -14,6 +14,9 @@
         "CoreUsage": "2",
         "LogDirectory": ""
 	},
+	"BIDSValidationOptions": {
+		"LogDirectory": ""
+	},
 	"FMRIPrepOptions": {
 		"BIDSDirectory": "",
 		"WorkingDirectory": "",

--- a/clpipe/data/defaultConvConfig.json
+++ b/clpipe/data/defaultConvConfig.json
@@ -4,6 +4,9 @@
             "dataType": "func",
             "modalityLabel": "bold",
             "customLabels": "task-srt",
+            "sidecarChanges":{
+				"TaskName": "srt"
+			},
             "criteria": {
 				"SeriesDescription":"*_srt",
                 "ImageType": ["ORIG*", "PRIMARY", "M", "ND", "MOSAIC"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='clpipe',
-      version='1.4.1',
+      version='1.4.2',
       description='clpipe: MRI processing pipeline for high performance clusters',
       url='https://github.com/cohenlabUNC/clpipe',
       author='Maintainer: Teague Henry, Contributor: Deepak Melwani',


### PR DESCRIPTION
- Include TaskName sidecar change by default in dcm2bids template
- Automatically include a .bidsignore folder in bids folder, if not present
- Add a dedicated log folder for bids validation output
- UseAroma is now its own configuration option - no longer needs to be added as an extra option for fmriprep as "--use-aroma"

closes #204 
closes #196 
closes #195 
closes #148