### PR TITLE
Adjust default config documentation.

### DIFF
--- a/docs/postprocessing.rst
+++ b/docs/postprocessing.rst
@@ -165,7 +165,7 @@ Otherwise, this block will be included when running "project setup."
 		],
 		"ProcessingStepOptions": {
 			"TemporalFiltering": {
-				"Implementation":"Butterworth",
+				"Implementation":"fslmaths",
 				"FilteringHighPass": 0.008,
 				"FilteringLowPass": -1,
 				"FilteringOrder": 2
@@ -178,7 +178,7 @@ Otherwise, this block will be included when running "project setup."
 				"FWHM": 6
 			},
 			"AROMARegression":{
-				"Implementation": "fsl_regfilt"
+				"Implementation": "fsl_regfilt_R"
 			},
 			"Resample":{
 				"ReferenceImage": "SET REFERENCE IMAGE"


### PR DESCRIPTION
Make sure temporal filtering and AROMAregression show the right default implementations.