### PR TITLE
fmri_postprocess: Fix the -TR Flag

### DIFF
--- a/clpipe/fmri_postprocess.py
+++ b/clpipe/fmri_postprocess.py
@@ -98,7 +98,7 @@ def fmri_postprocess(config_file=None, subjects=None, target_dir=None, target_su
     if task is not None:
         task_string = '-task='+task
     if tr is not None:
-        tr_string = '-tr='+tr
+        tr_string = '-TR='+tr
     if beta_series:
         beta_series_string = '-beta_series'
     if processing_stream is not None:
@@ -203,7 +203,8 @@ def _fmri_postprocess_image(config, file, task = None, tr=None, beta_series = Fa
             image_json_path = _find_json(config, file)
             with open(os.path.abspath(image_json_path), "r") as json_path:
                 image_json = json.load(json_path)
-            tr = float(image_json['RepetitionTime'])
+            tr = image_json['RepetitionTime']
+        tr = float(tr)
         logging.info('TR found: ' + str(tr))
         image = nib.load(file)
         data = image.get_fdata()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='clpipe',
-      version='1.5.0.4',
+      version='1.5.0.5',
       description='clpipe: MRI processing pipeline for high performance clusters',
       url='https://github.com/cohenlabUNC/clpipe',
       author='Maintainer: Teague Henry, Contributor: Will Asciutto, Contributor: Deepak Melwani',


### PR DESCRIPTION
Ensure the -TR flag is capitalized when distributing as expected by the cli. Ensure the tr is a float even if it comes from cli.