### PR TITLE
1.7.1.1 hotfix

### DIFF
--- a/clpipe/cli.py
+++ b/clpipe/cli.py
@@ -112,7 +112,7 @@ def _add_commands():
     glm_cli.add_command(fsl_onset_extract_cli, help_priority=2)
     glm_cli.add_command(report_outliers_cli, help_priority=7)
 
-    roi_cli.add_command(get_availablea_atlases_cli, help_priority=1)
+    roi_cli.add_command(get_available_atlases_cli, help_priority=1)
     roi_cli.add_command(fmri_roi_extraction_cli, help_priority=2)
 
     cli.add_command(bids_cli, help_priority=2)
@@ -542,7 +542,7 @@ def fmri_roi_extraction_cli(subjects, config_file, target_dir, target_suffix,
 
 
 @click.command("atlases")
-def get_availablea_atlases_cli():
+def get_available_atlases_cli():
     """Display all available atlases."""
     from .roi_extractor import get_available_atlases
     get_available_atlases()

--- a/clpipe/cli.py
+++ b/clpipe/cli.py
@@ -438,9 +438,7 @@ def glm_apply_mumford_workaround_cli(glm_config_file, l1_feat_folders_path,
 def glm_launch_cli(level, model, glm_config_file, test_one, submit, debug):
     """Launch all prepared .fsf files for L1 or L2 GLM analysis.
     
-    L1 can be any of: 1, L1, l1, or level1.
-
-    L2 can be any of: 2, L2, l2, or level2.
+    LEVEL is the level of anlaysis, L1 or L2
 
     MODEL must be a a corresponding L1 or L2 model from your GLM configuration file.
     """

--- a/clpipe/cli.py
+++ b/clpipe/cli.py
@@ -572,7 +572,7 @@ def report_outliers_cli(confounds_dir, confounds_file, output_file,
         get_image_confounds(confounds_file)
 
 
-@click.command(STATUS_COMMAND_NAME)
+@click.command(STATUS_COMMAND_NAME, no_args_is_help=True)
 @click.option('-config_file', type=CLICK_FILE_TYPE_EXISTS,
               help=CONFIG_HELP, required=False)
 @click.option('-cache_file', type=CLICK_FILE_TYPE_EXISTS,

--- a/clpipe/cli.py
+++ b/clpipe/cli.py
@@ -46,7 +46,8 @@ class OrderedHelpGroup(click.Group):
         return super().add_command(cmd, name)
 
 
-@click.group(cls=OrderedHelpGroup, context_settings=CONTEXT_SETTINGS)
+@click.group(cls=OrderedHelpGroup, context_settings=CONTEXT_SETTINGS,
+    invoke_without_command=True)
 @click.pass_context
 @click.option("-v", "--version", is_flag=True, default=False, 
         help=VERSION_HELP)

--- a/docs/bids_convert.rst
+++ b/docs/bids_convert.rst
@@ -154,6 +154,6 @@ This command will create convert an entire folder's data, and create a temporary
 Once you have updated your conversion configuration file, you can convert your entire dataset with:
 
 
-.. click:: clpipe.bids_conversion:convert2bids_cli
+.. click:: clpipe.cli:convert2bids_cli
    :prog: convert2bids
    :nested: full

--- a/docs/bids_validation.rst
+++ b/docs/bids_validation.rst
@@ -9,6 +9,6 @@ This function uses a Singularity image of the
 The output of this command will appear in your `logs/bids_validation_logs` folder
 by default.
 
-.. click:: clpipe.bids_validator:bids_validate_cli
+.. click:: clpipe.cli:bids_validate_cli
    :prog: bids_validate
    :nested: full

--- a/docs/fmriprep.rst
+++ b/docs/fmriprep.rst
@@ -12,7 +12,7 @@ increase the `[FMRIPrepOptions][FMRIPrepMemoryUsage]` option in the configuratio
 To submit your dataset for preprocessing, 
 use the following command:
 
-.. click:: clpipe.fmri_preprocess:fmriprep_process_cli
+.. click:: clpipe.cli:fmriprep_process_cli
    :prog: fmriprep_process
    :nested: full
 

--- a/docs/glm.rst
+++ b/docs/glm.rst
@@ -160,26 +160,26 @@ run the ``project_setup`` function.
 Commands
 -------------------------------
 
-.. click:: clpipe.glm_setup:glm_setup_cli
+.. click:: clpipe.cli:glm_setup_cli
 	:prog: glm_setup
 	:nested: full
 
-.. click:: clpipe.fsl_onset_extract:fsl_onset_extract_cli
+.. click:: clpipe.cli:fsl_onset_extract_cli
 	:prog: fsl_onset_extract
 	:nested: full
 
-.. click:: clpipe.glm_l1:glm_l1_preparefsf_cli
+.. click:: clpipe.cli:glm_l1_preparefsf_cli
 	:prog: glm_l1_preparefsf
 	:nested: full
 
-.. click:: clpipe.glm_launch:glm_l1_launch_cli
+.. click:: clpipe.cli:glm_l1_launch_cli
 	:prog: glm_l1_launch
 	:nested: full
 
-.. click:: clpipe.glm_l2:glm_l2_preparefsf_cli
+.. click:: clpipe.cli:glm_l2_preparefsf_cli
 	:prog: glm_l2_preparefsf
 	:nested: full
 
-.. click:: clpipe.glm_launch:glm_l2_launch_cli
+.. click:: clpipe.cli:glm_l2_launch_cli
 	:prog: glm_l2_launch
 	:nested: full

--- a/docs/postprocessing.rst
+++ b/docs/postprocessing.rst
@@ -8,7 +8,7 @@ processing steps that need to be taken after the minimal preprocessing of fMRIPr
 clpipe implements these steps in Python, and a fMRIprep preprocessed dataset can 
 be postprocessed using the following command:
 
-.. click:: clpipe.fmri_postprocess:fmri_postprocess_cli
+.. click:: clpipe.cli:fmri_postprocess_cli
 	:prog: fmri_postprocess
 	:nested: full
 

--- a/docs/project_setup.rst
+++ b/docs/project_setup.rst
@@ -40,6 +40,6 @@ This command will create the necessary directory structures, as well as create a
     |   |-- ROI_extraction_logs
     |-- scripts
 
-.. click:: clpipe.project_setup:project_setup_cli
+.. click:: clpipe.cli:project_setup_cli
 	:prog: project_setup
 	:nested: full

--- a/docs/roi_extraction.rst
+++ b/docs/roi_extraction.rst
@@ -13,13 +13,13 @@ be extracted without respect to the brain mask, and then ROIs with
 fewer than "PropVoxels" voxels will be set to NAN. This is a workaround for 
 the limitations on Nilearn's ROI extractor functions.
 
-.. click:: clpipe.roi_extractor:fmri_roi_extraction
+.. click:: clpipe.cli:fmri_roi_extraction_cli
 	:prog: fmri_roi_extraction
 	:nested: full
 
 To view the available built-in atlases, you can use the ``get_available_atlases`` 
 command.
 
-.. click:: clpipe.roi_extractor:get_available_atlases
+.. click:: clpipe.cli:get_available_atlases_cli
 	:prog: get_available_atlases
 	:nested: full

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='clpipe',
-      version='1.7.1',
+      version='1.7.1.1',
       description='clpipe: MRI processing pipeline for high performance clusters',
       url='https://github.com/cohenlabUNC/clpipe',
       author='Maintainer: Teague Henry, Maintainer: Will Asciutto, Contributor: Deepak Melwani',


### PR DESCRIPTION
- Return accidentally removed "invoke_without_command" parameter to top cli function so that `clpipe -v` can be called
- Calling `clpipe status` without arguments now displays help info like the other commands instead of giving a missing input error
- Modify `glm launch` help description to match command name
- Update CLI documentation references to fix click command links broken by moving all CLI commands back to cli module
- Fix spelling of show atlases command name