### PR TITLE
1.7.1.2 hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 
 ## Directory-based project format:
 .idea/
-venv/
-venv3.7.14/
+venv*
 build/
 dist/
 clpipe.egg-info/

--- a/clpipe/fmri_postprocess.py
+++ b/clpipe/fmri_postprocess.py
@@ -13,7 +13,10 @@ import re
 
 from pkg_resources import resource_filename
 
-import clpipe.postprocutils
+from .postprocutils.utils import (
+    scrub_setup, calc_filter, apply_filter, regress, scrub_image, notch_filter
+)
+from .postprocutils.spec_interpolate import spec_inter
 from .batch_manager import BatchManager, Job
 from .config_json_parser import ClpipeConfigParser
 from .error_handler import exception_handler
@@ -222,7 +225,7 @@ def _fmri_postprocess_image(config, file, task = None, tr=None, beta_series = Fa
             if config.config['PostProcessingOptions']['RespNotchFilter']:
                 fdts = _notch_filter_fd(config,  confound_regressors, tr, drop_tps)
 
-            scrubTargets = clpipe.postprocutils.utils.scrub_setup(fdts, fd_thres, scrub_behind, scrub_ahead, scrub_contig)
+            scrubTargets = scrub_setup(fdts, fd_thres, scrub_behind, scrub_ahead, scrub_contig)
 
         hp = float(config.config['PostProcessingOptions']['FilteringHighPass'])
         lp = float(config.config['PostProcessingOptions']['FilteringLowPass'])
@@ -231,15 +234,15 @@ def _fmri_postprocess_image(config, file, task = None, tr=None, beta_series = Fa
             logging.info('Filtering Toggle Activated')
             filter_toggle = True
             order = int(config.config['PostProcessingOptions']['FilteringOrder'])
-            filt = clpipe.postprocutils.utils.calc_filter(hp, lp, tr, order)
-            confounds = clpipe.postprocutils.utils.apply_filter(filt, confounds)
+            filt = calc_filter(hp, lp, tr, order)
+            confounds = apply_filter(filt, confounds)
 
         if scrub_toggle and filter_toggle:
             logging.info('Using Spectral Interpolation')
             ofreq = int(config.config['PostProcessingOptions']['OversamplingFreq'])
             hfreq = float(config.config['PostProcessingOptions']['PercentFreqSample'])
             logging.debug('Memory Usage Before Spectral Interpolation:' +str(psutil.virtual_memory().total >> 30) +' GB')
-            data = clpipe.postprocutils.spec_interpolate.spec_inter(data, tr, ofreq, scrubTargets, hfreq, binSize=config.config['PostProcessingOptions']["SpectralInterpolationBinSize"])
+            data = spec_inter(data, tr, ofreq, scrubTargets, hfreq, binSize=config.config['PostProcessingOptions']["SpectralInterpolationBinSize"])
 
         gc.collect()
 
@@ -249,15 +252,15 @@ def _fmri_postprocess_image(config, file, task = None, tr=None, beta_series = Fa
 
         if filter_toggle:
             logging.info('Filtering Data Now')
-            data = clpipe.postprocutils.utils.apply_filter(filt, data)
+            data = apply_filter(filt, data)
         if regress_toggle:
             logging.info('Regressing Data Now')
             logging.debug(str(confounds.shape))
             logging.debug(str(data.shape))
-            data = clpipe.postprocutils.utils.regress(confounds, data)
+            data = regress(confounds, data)
         if scrub_toggle:
             logging.info('Scrubbing data Now')
-            data = clpipe.postprocutils.utils.scrub_image(data, scrubTargets)
+            data = scrub_image(data, scrubTargets)
 
         data = (data + row_means)
 
@@ -311,8 +314,8 @@ def _fmri_postprocess_image(config, file, task = None, tr=None, beta_series = Fa
                 logging.info('Filtering Toggle Activated')
                 filter_toggle = True
                 order = int(config.config['BetaSeriesOptions']['FilteringOrder'])
-                filt = clpipe.postprocutils.utils.calc_filter(hp, lp, tr, order)
-                confounds = clpipe.postprocutils.utils.apply_filter(filt, confounds)
+                filt = calc_filter(hp, lp, tr, order)
+                confounds = apply_filter(filt, confounds)
             filt_ev_array, valid_events = _ev_mat_prep(events_file, filt, tr, ntp, beta_series_options)
 
             image = nib.load(file)
@@ -369,7 +372,7 @@ def _ev_mat_prep(event_file, filt, TR, ntp, config_block):
         ev_loop = ev_loop[indexSample]
         eventArray[:, index] = ev_loop
     if filt is not None:
-        filt_event_array = clpipe.postprocutils.utils.apply_filter(filt, eventArray)
+        filt_event_array = apply_filter(filt, eventArray)
     else:
         filt_event_array = eventArray
     return filt_event_array, valid_events
@@ -545,7 +548,7 @@ def _notch_filter_fd(config, confounds_filepath, tr, drop_tps = None):
         confounds = confounds.iloc[:(confounds.shape[0]-drop_tps)]
     confounds = numpy.array(confounds[config.config["PostProcessingOptions"]["MotionVars"]])
     band = config.config['PostProcessingOptions']['RespNotchFilterBand']
-    filt_fd = clpipe.postprocutils.utils.notch_filter(confounds, band, tr)
+    filt_fd = notch_filter(confounds, band, tr)
     return filt_fd
 
 def regex_wildcard(string):

--- a/clpipe/glm_setup.py
+++ b/clpipe/glm_setup.py
@@ -2,6 +2,7 @@ import os
 import glob
 import click
 from .batch_manager import BatchManager, Job
+from .postprocutils.utils import scrub_setup
 from .config_json_parser import ClpipeConfigParser, GLMConfigParser
 import logging
 import sys
@@ -17,7 +18,6 @@ from nipype.interfaces.utility import IdentityInterface
 import nibabel as nib
 import pandas
 import re
-import clpipe.postprocutils
 import numpy as np
 
 
@@ -210,7 +210,7 @@ def _glm_prep(glm_config, subject, task, drop_tps):
                     logging.info("Contiguous: " + str(glm_config.config["GLMSetupOptions"]['ScrubContiguous']))
                     fdts = confounds[glm_config.config["GLMSetupOptions"]['ScrubVar']]
                     logging.debug(str(fdts))
-                    scrub_targets = clpipe.postprocutils.utils.scrub_setup(fdts, glm_config.config["GLMSetupOptions"]['Threshold'], glm_config.config["GLMSetupOptions"]['ScrubBehind'], glm_config.config["GLMSetupOptions"]['ScrubAhead'], glm_config.config["GLMSetupOptions"]['ScrubContiguous'])
+                    scrub_targets = scrub_setup(fdts, glm_config.config["GLMSetupOptions"]['Threshold'], glm_config.config["GLMSetupOptions"]['ScrubBehind'], glm_config.config["GLMSetupOptions"]['ScrubAhead'], glm_config.config["GLMSetupOptions"]['ScrubContiguous'])
                     logging.debug(str(scrub_targets))
             if drop_tps is not None:
                 img_data = nib.load(image)
@@ -226,10 +226,11 @@ def _glm_prep(glm_config, subject, task, drop_tps):
                     if confounds is not None:
                         confounds_mat = confounds_mat.head(total_tps)
                         fdts = fdts.iloc[:(fdts.shape[0]-(tps_drop))]
-                    scrub_targets = clpipe.postprocutils.utils.scrub_setup(fdts, glm_config.config["GLMSetupOptions"]['Threshold'],
-                                                                            glm_config.config["GLMSetupOptions"]['ScrubBehind'],
-                                                                            glm_config.config["GLMSetupOptions"]['ScrubAhead'],
-                                                                            glm_config.config["GLMSetupOptions"]['ScrubContiguous'])
+                    scrub_targets = scrub_setup(fdts,
+                                                glm_config.config["GLMSetupOptions"]['Threshold'],
+                                                glm_config.config["GLMSetupOptions"]['ScrubBehind'],
+                                                glm_config.config["GLMSetupOptions"]['ScrubAhead'],
+                                                glm_config.config["GLMSetupOptions"]['ScrubContiguous'])
                 logging.info("Total timepoints are " + str(total_tps))
                 glm_setup.inputs.drop_tps.t_size = total_tps
             glm_setup.inputs.input.in_file = os.path.abspath(image)

--- a/clpipe/postprocutils/utils.py
+++ b/clpipe/postprocutils/utils.py
@@ -1,7 +1,3 @@
-import pkg_resources
-import sys
-import getpass
-sys.path.insert(0,"/nas/longleaf/home/"+getpass.getuser()+"/.local/lib/python3.6/site-packages")
 import numpy
 from scipy.signal import butter, sosfilt, iirnotch, filtfilt
 import logging

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='clpipe',
-      version='1.7.1.1',
+      version='1.7.1.2',
       description='clpipe: MRI processing pipeline for high performance clusters',
       url='https://github.com/cohenlabUNC/clpipe',
       author='Maintainer: Teague Henry, Maintainer: Will Asciutto, Contributor: Deepak Melwani',


### PR DESCRIPTION
Fixes import regression bugs in the original postprocessing command causing it to fail to run.

Basically just adjusting the imports from postproc utils. There is also a stray direct reference to python 3.6 that had to be removed due to us being on 3.7 now.

closes #285 