### PR TITLE
Release 1.7.2

### DIFF
--- a/docs/dicom_sync.rst
+++ b/docs/dicom_sync.rst
@@ -55,19 +55,17 @@ flywheel_sync Options
 Using with convert2bids
 -------------------------------
 
-Unfortunately, Flywheel creates a DICOM folder structure that is too deep for the
+Flywheel creates a DICOM folder structure that is too deep for the
 default depth setting of dcm2niix, which both dcm2bids and heudiconv use to discover
-DICOM files in your source directory.
-
-To fix this issue, you must pass through the argument `-d 9` to dcm2niix, which
-sets the default search depth to the maximum.
+DICOM files in your source directory. However, dcm2niix can be configured to search
+deeper with the `-d` option:
 
  
 dcm2bids (clpipe default)
 ----------------
 
-You can set the depth flag with dcm2bids by copying the `dcm2niixOptions`
-key to your conversion_config.json file, like this:
+dcm2bids provides a method of passing options through to dcm2niix by adding a
+`dcm2niixOptions` item to your conversion conversion_config.json file, like this:
 
 .. code-block :: json
 
@@ -90,11 +88,15 @@ key to your conversion_config.json file, like this:
 You must include all options shown, because this argument overwrites the dcm2niixOptions,
 as opposed to just appending to them.
 
+The options above add the `-d 9` option, setting dcm2niix's search depth to the maximum
+value.
+
 heudiconv
 ----------------
 
-By default, heudiconv searches deeply enough to find DICOM files within Flywheel's
-output structure.
+By default, heudiconv sets the search depth of dcm2niix high enough to find 
+DICOM files within Flywheel's output structure, so no changes are required if you
+use this converter.
 
 
 -------------------------------

--- a/docs/dicom_sync.rst
+++ b/docs/dicom_sync.rst
@@ -52,6 +52,52 @@ flywheel_sync Options
 	:nested: full
 
 -------------------------------
+Using with convert2bids
+-------------------------------
+
+Unfortunately, Flywheel creates a DICOM folder structure that is too deep for the
+default depth setting of dcm2niix, which both dcm2bids and heudiconv use to discover
+DICOM files in your source directory.
+
+To fix this issue, you must pass through the argument `-d 9` to dcm2niix, which
+sets the default search depth to the maximum.
+
+ 
+dcm2bids (clpipe default)
+----------------
+
+You can set the depth flag with dcm2bids by copying the `dcm2niixOptions`
+key to your conversion_config.json file, like this:
+
+.. code-block :: json
+
+	{
+	"dcm2niixOptions": "-b y -ba y -z y -f '%3s_%f_%p_%t' -d 9",
+	"descriptions": [
+		{
+			"dataType": "anat",
+			"modalityLabel": "T1w",
+			"criteria": {
+				"SeriesDescription": "ADNI3_t1_mprag_sag_p2_iso"
+			}
+		},
+		{
+			"criteria": {
+				"SeriesDescription": "RIDL1"
+			},
+	...
+
+You must include all options shown, because this argument overwrites the dcm2niixOptions,
+as opposed to just appending to them.
+
+heudiconv
+----------------
+
+By default, heudiconv searches deeply enough to find DICOM files within Flywheel's
+output structure.
+
+
+-------------------------------
 Additional Notes
 -------------------------------
 

--- a/docs/dicom_sync.rst
+++ b/docs/dicom_sync.rst
@@ -27,11 +27,24 @@ and your batch configuration:
    
 	"SourceOptions": {
 		"SourceURL": "fw://<LAB>/<STUDY>/",
-		"DropoffDirectory": "path/to/your/dicom_folder",
+		"DropoffDirectory": "/path/to/your/dicom_folder",
+		"TempDirectory": "/path/to/a/temp_folder",
+		"CommandLineOpts": "",
 		"TimeUsage": "1:0:0",
 		"MemUsage": "10000",
 		"CoreUsage": "1"
 	},
+
+
+flywheel_sync Options
+----------------
+
+* ``SourceOptions:`` Options regarding remote data sources.
+
+    * ``SourceURL:`` The URL to your source data - for Flywheel this should start with `fw:` and point to a project. You can use `fw ls` to browse your fw project space to find the right path.
+    * ``DropoffDirectory:`` A destination for your synced data - usually this will be `data_DICOMs`
+    * ``TempDirectory`` A location for Flywheel to store its temporary files - necessary on shared compute, because Flywheel will use system level tmp space by default, which can cause issues.
+    * ``CommandLineOpts:`` Any additional options you may need to include - you can browse Flywheel sync's other options with `fw sync --help`
 
 
 .. click:: clpipe.cli:flywheel_sync_cli


### PR DESCRIPTION
Short augmentation to the flywheel_sync documentation to add some detail about configuring a temporary directory, and describes how to set search depth options for dcm2bids.