### PR TITLE
1.7.2.2 hotfix

### DIFF
--- a/clpipe/config.py
+++ b/clpipe/config.py
@@ -117,7 +117,7 @@ PROCESSING_STREAM_HELP = \
 INDEX_HELP = 'Give the path to an existing pybids index database.'
 REFRESH_INDEX_HELP = \
     'Refresh the pybids index database to reflect new fmriprep artifacts.'
-DEFAULT_PROCESSING_STREAM = "smooth-filter-normalize"
+DEFAULT_PROCESSING_STREAM = "default"
 
 # GLM Help
 GLM_SETUP_COMMAND_NAME = "setup"

--- a/clpipe/fmri_postprocess2.py
+++ b/clpipe/fmri_postprocess2.py
@@ -109,6 +109,10 @@ def postprocess_subjects(
     else:
         logger.info(f"Using working directory: {working_dir}")
 
+    stream_output_dir = output_dir / processing_stream
+    if not stream_output_dir.exists():
+        stream_output_dir.mkdir(parents=True)
+
     if not log_dir:
         log_dir = Path(project_dir) / "logs" / "postproc2_logs"
     log_dir = Path(log_dir)
@@ -218,14 +222,15 @@ def postprocess_subject(
     config = _parse_config(config_file)
     config_file = Path(config_file)
 
+    output_dir = Path(output_dir)
+
+    stream_output_dir = output_dir / processing_stream
     postprocessing_config = _fetch_postprocessing_stream_config(
-        config, output_dir, processing_stream=processing_stream)
+        config, stream_output_dir, processing_stream=processing_stream)
 
     batch_manager = None
     if batch:
         batch_manager = _setup_batch_manager(config, log_dir)
-
-    output_dir = Path(output_dir)
 
     try:
         bids:BIDSLayout = get_bids(
@@ -325,10 +330,9 @@ def postprocess_image(
     config = _parse_config(config_file)
     config_file = Path(config_file)
 
+    stream_output_dir = Path(out_dir) / processing_stream
     postprocessing_config = _fetch_postprocessing_stream_config(
-        config, out_dir, processing_stream=processing_stream)
-
-    stream_dir = Path(out_dir) / processing_stream
+        config, stream_output_dir, processing_stream=processing_stream)
 
     image_path = Path(image_path)
     subject_working_dir = Path(subject_working_dir)
@@ -415,7 +419,7 @@ def postprocess_image(
         base_dir=subject_working_dir, crashdump_dir=log_dir)
     
     if postprocessing_config["WriteProcessGraph"]:
-        _draw_graph(postproc_wf, "processing_graph", stream_dir, logger=logger)
+        _draw_graph(postproc_wf, "processing_graph", stream_output_dir, logger=logger)
 
     postproc_wf.inputs.inputnode.in_file = image_path
     postproc_wf.inputs.inputnode.confounds_file = confounds_path
@@ -534,7 +538,7 @@ def _plot_image_sample(image_path: os.PathLike,
 
 
 def _fetch_postprocessing_stream_config(
-    config: dict, output_dir: os.PathLike, 
+    config: dict, stream_output_dir: os.PathLike, 
     processing_stream:str=DEFAULT_PROCESSING_STREAM):
     """
     The postprocessing stream config is a subset of the main 
@@ -545,9 +549,6 @@ def _fetch_postprocessing_stream_config(
     file at the level of the output folder / stream folder and
     is referred to by the workflow builders.
     """
-    stream_output_dir = Path(output_dir) / processing_stream
-    if not stream_output_dir.exists():
-        stream_output_dir.mkdir(parents=True)
 
     postprocessing_description_file = \
         Path(stream_output_dir) / PROCESSING_DESCRIPTION_FILE_NAME

--- a/clpipe/fmri_postprocess2.py
+++ b/clpipe/fmri_postprocess2.py
@@ -591,7 +591,7 @@ def _postprocessing_config_apply_processing_stream(
     
     # If using the default stream, no need to update postprocessing config
     if processing_stream == DEFAULT_PROCESSING_STREAM:
-        return
+        return postprocessing_config
 
     # Iterate through the available processing streams and see 
     #   if one matches the one requested

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='clpipe',
-      version='1.7.2',
+      version='1.7.2.1',
       description='clpipe: MRI processing pipeline for high performance clusters',
       url='https://github.com/cohenlabUNC/clpipe',
       author='Maintainer: Teague Henry, Maintainer: Will Asciutto, Contributor: Deepak Melwani',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='clpipe',
-      version='1.7.2.1',
+      version='1.7.2.2',
       description='clpipe: MRI processing pipeline for high performance clusters',
       url='https://github.com/cohenlabUNC/clpipe',
       author='Maintainer: Teague Henry, Maintainer: Will Asciutto, Contributor: Deepak Melwani',


### PR DESCRIPTION
Fixes a race condition that causes postproc2 jobs to fail when they are creating directories for the first time.

Basically, its not smart to try to create the same file in multiple parallel jobs...

Also, fixes the default postproc2 stream, which I didn't notice was failing because I always tested with a specific stream.