### PR TITLE
1.8.0.2 hotfix

### DIFF
--- a/clpipe/cli.py
+++ b/clpipe/cli.py
@@ -1,6 +1,8 @@
+# Note: these imports must remain light to ensure the CLI runs quickly.
+# Do not import any sub-command dependencies here directly! Lazy-load them by
+#   importing within their respective CLI commands.
 import click
 import sys
-from .fmri_process_check import fmri_process_check
 from .config.cli import *
 from .config.postprocessing2 import DEFAULT_PROCESSING_STREAM
 from .config.package import VERSION

--- a/clpipe/config/package.py
+++ b/clpipe/config/package.py
@@ -1,5 +1,5 @@
 PACKAGE_NAME = 'clpipe'
-VERSION = '1.8.0.1'
+VERSION = '1.8.0.2'
 
 DESCRIPTION = 'clpipe: MRI processing pipeline for high performance clusters'
 REPO_URL = 'https://github.com/cohenlabUNC/clpipe'

--- a/clpipe/config/package.py
+++ b/clpipe/config/package.py
@@ -1,5 +1,5 @@
 PACKAGE_NAME = 'clpipe'
-VERSION = '1.8.0'
+VERSION = '1.8.0.1'
 
 DESCRIPTION = 'clpipe: MRI processing pipeline for high performance clusters'
 REPO_URL = 'https://github.com/cohenlabUNC/clpipe'

--- a/clpipe/data/defaultConfig.json
+++ b/clpipe/data/defaultConfig.json
@@ -131,7 +131,7 @@
       			"FWHM": 6
 			},
 			"AROMARegression":{
-				"Implementation": "fsl_regfilt_R"
+				"Implementation": "fsl_regfilt"
 			},
 			"Resample":{
 				"ReferenceImage": "SET REFERENCE IMAGE"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,12 +156,12 @@ def clpipe_dicom_dir(tmp_path_factory):
     return project_dir
 
 @pytest.fixture(scope="session")
-def clpipe_bids_dir(tmp_path_factory):
+def clpipe_bids_dir(tmp_path_factory, sample_raw_image):
     """Fixture provides a clpipe project with mock BIDS folders."""
 
     project_dir = tmp_path_factory.mktemp("clpipe_bids_dir")
     project_setup(project_title=PROJECT_TITLE, project_dir=str(project_dir))
-    utils.populate_with_BIDS(project_dir)
+    utils.populate_with_BIDS(project_dir, sample_raw_image)
 
     return clpipe_dir
 
@@ -233,7 +233,7 @@ def clpipe_dir_old_glm_config(tmp_path_factory, sample_raw_image, sample_raw_ima
     GLMConfigParser.__init__ = utils.old_GLMConfigParser_init
 
     project_setup(project_title=PROJECT_TITLE, project_dir=project_dir)
-    utils.populate_with_BIDS(project_dir)
+    utils.populate_with_BIDS(project_dir, sample_raw_image)
     utils.populate_with_fmriprep(project_dir, sample_raw_image, sample_raw_image_mask, 
         sample_confounds_timeseries, sample_melodic_mixing, sample_aroma_noise_ics, 
         sample_fmriprep_dataset_description, legacy=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,15 @@ from pathlib import Path
 
 from clpipe.cli import *
 
+def test_cli():
+    """Simple test to ensure the main clpipe commmand runs without error."""
+
+    with pytest.raises(SystemExit) as e:
+        cli([])
+
+    assert e.value.code == 0
+
+
 def test_glm_l1_launch_cli(glm_config_file: Path):
     """Test that 'classic' style glm_l1_launch_cli launch command works"""
 


### PR DESCRIPTION
Fixes an issue where the Confound Regression step was demeaning the timeseries data when using 3DTProject.

This update adds back the mean after 3DTProject runs.

Also fixes an issues where the default config file uses the algorithm "fsl_regfilt_R" for AROMA regression when it should be "fsl_regfilt," because the confound pipeline will use the R variant automatically.

closes #348 