### PR TITLE
Resolve issue with threads not being passed correctly in job manager

### DIFF
--- a/clpipe/job_manager.py
+++ b/clpipe/job_manager.py
@@ -97,7 +97,7 @@ class BatchJobManager(JobManager):
         if self.config.thread_command_active:
             head.append(
                 self.config.n_threads_command.format(
-                    nthreads=self.config.n_threads_default
+                    nthreads=self.config.threads
                 )
             )
         if self.config.job_id_command_active:


### PR DESCRIPTION
This PR hopes to finally resolve the issue with the threads not being passed in correctly. The last hotfix addressed the issue with the fmriprep preprocess function not getting the correct config arguments. But it turned out that issue also propagated further with those config arguments now not being passed in correctly to the batch manager.

This time, I did a more robust test by running the command on a test subject and ensuring the correct command is executed. I was able to verify on my end that the cpus-per-task are indeed set to the correct value based on the config file now. There was a couple of other issues I noticed as well, but I am making this PR out as soon as I can to get clpipe 1.9.1 back on track!

I would appreciate a speedy review @trh3! Cheers!