### PR TITLE
fix r version issue

### DIFF
--- a/.lmod/module_file_template.txt
+++ b/.lmod/module_file_template.txt
@@ -17,7 +17,7 @@ unload("python")
 load("freesurfer/6.0.0")
 load("fsl/6.0.3")
 load("afni/20.3.00")
-load("r/4.2.1")
+load("r")
 load("dcm2niix/1.0.20211006")
 load("flywheel/16.19.0")
 

--- a/.lmod/setup_modules.sh
+++ b/.lmod/setup_modules.sh
@@ -11,7 +11,7 @@ module purge
 module load fsl/6.0.3
 module load freesurfer/6.0.0
 module load afni/20.3.00
-module load r/4.2.1
+module load r
 module load flywheel/16.4.0
 module load dcm2niix/1.0.20211006
 


### PR DESCRIPTION
r/4.2.1 is not required for clpipe purposes. On the Longleaf RHEL9 systems we have r/4.4.0 and r/4.5.0 which meet requirements in terms of versions.